### PR TITLE
add idp settings

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -22,6 +22,10 @@ resource "pomerium_namespace" "test_namespace" {
 
 resource "pomerium_settings" "settings" {
   installation_id = "localhost-dev"
+  identity_provider_okta = {
+    api_key = "key"
+    url     = "http://localhost"
+  }
 }
 
 resource "pomerium_policy" "test_policy" {

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,12 @@ go 1.23.0
 
 require (
 	github.com/go-jose/go-jose/v3 v3.0.3
-	github.com/hashicorp/terraform-plugin-framework v1.11.0
-	github.com/hashicorp/terraform-plugin-go v0.23.0
+	github.com/google/go-cmp v0.6.0
+	github.com/hashicorp/terraform-plugin-framework v1.13.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
+	github.com/hashicorp/terraform-plugin-go v0.25.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
+	github.com/iancoleman/strcase v0.3.0
 	github.com/pomerium/enterprise-client-go v0.18.1-0.20241202185750-aab20a674922
 	github.com/pomerium/pomerium v0.28.0
 	github.com/rs/zerolog v1.33.0
@@ -31,7 +34,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-plugin v1.6.0 // indirect
+	github.com/hashicorp/go-plugin v1.6.2 // indirect
 	github.com/hashicorp/go-set/v3 v3.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+
 github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/go-plugin v1.6.0 h1:wgd4KxHJTVGGqWBq4QPB1i5BZNEx9BR8+OFmHDmTk8A=
-github.com/hashicorp/go-plugin v1.6.0/go.mod h1:lBS5MtSSBZk0SHc66KACcjjlU6WzEVP/8pwz68aMkCI=
+github.com/hashicorp/go-plugin v1.6.2 h1:zdGAEd0V1lCaU0u+MxWQhtSDQmahpkwOun8U8EiRVog=
+github.com/hashicorp/go-plugin v1.6.2/go.mod h1:CkgLQ5CZqNmdL9U9JzM532t8ZiYQ35+pj3b1FD37R0Q=
 github.com/hashicorp/go-set/v3 v3.0.0 h1:CaJBQvQCOWoftrBcDt7Nwgo0kdpmrKxar/x2o6pV9JA=
 github.com/hashicorp/go-set/v3 v3.0.0/go.mod h1:IEghM2MpE5IaNvL+D7X480dfNtxjRXZ6VMpK3C8s2ok=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
@@ -132,10 +132,12 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/terraform-plugin-framework v1.11.0 h1:M7+9zBArexHFXDx/pKTxjE6n/2UCXY6b8FIq9ZYhwfE=
-github.com/hashicorp/terraform-plugin-framework v1.11.0/go.mod h1:qBXLDn69kM97NNVi/MQ9qgd1uWWsVftGSnygYG1tImM=
-github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/125t+AAurhqphJ2Co=
-github.com/hashicorp/terraform-plugin-go v0.23.0/go.mod h1:1E3Cr9h2vMlahWMbsSEcNrOCxovCZhOOIXjFHbjc/lQ=
+github.com/hashicorp/terraform-plugin-framework v1.13.0 h1:8OTG4+oZUfKgnfTdPTJwZ532Bh2BobF4H+yBiYJ/scw=
+github.com/hashicorp/terraform-plugin-framework v1.13.0/go.mod h1:j64rwMGpgM3NYXTKuxrCnyubQb/4VKldEKlcG8cvmjU=
+github.com/hashicorp/terraform-plugin-framework-validators v0.16.0 h1:O9QqGoYDzQT7lwTXUsZEtgabeWW96zUBh47Smn2lkFA=
+github.com/hashicorp/terraform-plugin-framework-validators v0.16.0/go.mod h1:Bh89/hNmqsEWug4/XWKYBwtnw3tbz5BAy1L1OgvbIaY=
+github.com/hashicorp/terraform-plugin-go v0.25.0 h1:oi13cx7xXA6QciMcpcFi/rwA974rdTxjqEhXJjbAyks=
+github.com/hashicorp/terraform-plugin-go v0.25.0/go.mod h1:+SYagMYadJP86Kvn+TGeV+ofr/R3g4/If0O5sO96MVw=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
@@ -144,6 +146,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/provider/convert_test.go
+++ b/internal/provider/convert_test.go
@@ -5,14 +5,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/pomerium/enterprise-client-go/pb"
 	"github.com/pomerium/enterprise-terraform-provider/internal/provider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestFromStringSlice(t *testing.T) {
@@ -131,6 +135,188 @@ func TestToStringList(t *testing.T) {
 			assert.False(t, diagnostics.HasError())
 			if tt.validate != nil {
 				tt.validate(t, result)
+			}
+		})
+	}
+}
+
+func TestGoStructToPB(t *testing.T) {
+	type TestStruct struct {
+		FirstName types.String
+		LastName  types.String
+	}
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		want     *structpb.Struct
+		wantErr  bool
+		errorMsg string
+	}{
+		{
+			name: "basic test",
+			input: TestStruct{
+				FirstName: basetypes.NewStringValue("John"),
+				LastName:  basetypes.NewStringValue("Doe"),
+			},
+			want: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"first_name": structpb.NewStringValue("John"),
+					"last_name":  structpb.NewStringValue("Doe"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "nil input",
+			input:   nil,
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:  "empty struct",
+			input: TestStruct{},
+			want: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with nil StringValue",
+			input: TestStruct{
+				FirstName: basetypes.NewStringValue("John"),
+				LastName:  basetypes.NewStringNull(),
+			},
+			want: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"first_name": structpb.NewStringValue("John"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "non-struct input",
+			input:    123,
+			want:     nil,
+			wantErr:  true,
+			errorMsg: "input must be a struct, got int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := provider.GoStructToPB(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.EqualError(t, err, tt.errorMsg)
+				}
+				assert.Nil(t, got)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Empty(t, cmp.Diff(tt.want, got, protocmp.Transform()))
+		})
+	}
+}
+
+func TestPBStructToTF(t *testing.T) {
+	type TestStruct struct {
+		Field1 types.String `tfsdk:"field_one"`
+		Field2 types.String `tfsdk:"field_two"`
+	}
+
+	testCases := []struct {
+		name        string
+		src         *structpb.Struct
+		want        types.Object
+		wantErr     bool
+		wantWarning bool
+	}{
+		{
+			name: "successful conversion",
+			src: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"field_one": structpb.NewStringValue("value1"),
+					"field_two": structpb.NewStringValue("value2"),
+				},
+			},
+			want: types.ObjectValueMust(map[string]attr.Type{
+				"field_one": types.StringType,
+				"field_two": types.StringType,
+			}, map[string]attr.Value{
+				"field_one": types.StringValue("value1"),
+				"field_two": types.StringValue("value2"),
+			}),
+		},
+		{
+			name: "missing field in source",
+			src: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"field_one": structpb.NewStringValue("value1"),
+				},
+			},
+			want: types.ObjectValueMust(map[string]attr.Type{
+				"field_one": types.StringType,
+				"field_two": types.StringType,
+			}, map[string]attr.Value{
+				"field_one": types.StringValue("value1"),
+				"field_two": types.StringNull(),
+			}),
+		},
+		{
+			name: "nil source struct",
+			want: types.ObjectNull(map[string]attr.Type{
+				"field_one": types.StringType,
+				"field_two": types.StringType,
+			}),
+		},
+		{
+			name: "unexpected field in source",
+			src: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"field_one":  structpb.NewStringValue("value1"),
+					"field_two":  structpb.NewStringValue("value2"),
+					"unexpected": structpb.NewStringValue("value3"),
+				},
+			},
+			want: types.ObjectValueMust(map[string]attr.Type{
+				"field_one": types.StringType,
+				"field_two": types.StringType,
+			}, map[string]attr.Value{
+				"field_one": types.StringValue("value1"),
+				"field_two": types.StringValue("value2"),
+			}),
+			wantWarning: true,
+		},
+		{
+			name: "unsupported field type in source",
+			src: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"field_one": structpb.NewStringValue("value1"),
+					"field_two": structpb.NewNumberValue(123),
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := types.ObjectNull(map[string]attr.Type{
+				"field_one": types.StringType,
+				"field_two": types.StringType,
+			})
+			var diags diag.Diagnostics
+			provider.PBStructToTF[TestStruct](&dst, tc.src, &diags)
+
+			require.Equal(t, tc.wantErr, diags.HasError(), diags)
+			if tc.wantWarning {
+				assert.NotEmpty(t, diags.Warnings())
+			}
+
+			if !tc.wantErr {
+				assert.Empty(t, cmp.Diff(tc.want, dst))
 			}
 		})
 	}

--- a/internal/provider/idp_model.go
+++ b/internal/provider/idp_model.go
@@ -1,0 +1,165 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/pomerium/enterprise-client-go/pb"
+)
+
+type (
+	// Auth0Options are the options used for Auth0.
+	Auth0Options struct {
+		ClientID     types.String `tfsdk:"client_id"`
+		ClientSecret types.String `tfsdk:"client_secret"`
+		Domain       types.String `tfsdk:"domain"`
+	}
+
+	// AzureOptions are the options used for Azure.
+	AzureOptions struct {
+		ClientID     types.String `tfsdk:"client_id"`
+		ClientSecret types.String `tfsdk:"client_secret"`
+		DirectoryID  types.String `tfsdk:"directory_id"`
+	}
+
+	// CognitoOptions are the options used for Cognito.
+	CognitoOptions struct {
+		AccessKeyID     types.String `tfsdk:"access_key_id"`
+		Region          types.String `tfsdk:"region"`
+		SecretAccessKey types.String `tfsdk:"secret_access_key"`
+		SessionToken    types.String `tfsdk:"session_token"`
+		UserPoolID      types.String `tfsdk:"user_pool_id"`
+	}
+
+	// GitHubOptions are the options used for GitHub.
+	GitHubOptions struct {
+		Username            types.String `tfsdk:"username"`
+		PersonalAccessToken types.String `tfsdk:"personal_access_token"`
+	}
+
+	// GitLabOptions are the options used for GitLab.
+	GitLabOptions struct {
+		PrivateToken types.String `tfsdk:"private_token"`
+	}
+
+	// GoogleOptions are the options used for Google.
+	GoogleOptions struct {
+		ImpersonateUser types.String `tfsdk:"impersonate_user"`
+		JSONKey         types.String `tfsdk:"json_key"`
+		URL             types.String `tfsdk:"url"`
+	}
+
+	// OktaOptions are the options used for Okta.
+	OktaOptions struct {
+		APIKey types.String `tfsdk:"api_key"`
+		URL    types.String `tfsdk:"url"`
+	}
+
+	// OneLoginOptions are the options used for OneLogin.
+	OneLoginOptions struct {
+		ClientID     types.String `tfsdk:"client_id"`
+		ClientSecret types.String `tfsdk:"client_secret"`
+	}
+
+	// PingOptions are the options used for Ping.
+	PingOptions struct {
+		ClientID      types.String `tfsdk:"client_id"`
+		ClientSecret  types.String `tfsdk:"client_secret"`
+		EnvironmentID types.String `tfsdk:"environment_id"`
+	}
+)
+
+func IdentityProviderSettingsFromPB(
+	dst *SettingsModel,
+	src *pb.Settings,
+	diags *diag.Diagnostics,
+) {
+	if src.IdentityProvider == nil {
+		return
+	}
+	switch *src.IdentityProvider {
+	case "auth0":
+		PBStructToTF[Auth0Options](&dst.IdentityProviderAuth0, src.IdentityProviderOptions, diags)
+	case "azure":
+		PBStructToTF[AzureOptions](&dst.IdentityProviderAzure, src.IdentityProviderOptions, diags)
+	case "cognito":
+		PBStructToTF[CognitoOptions](&dst.IdentityProviderCognito, src.IdentityProviderOptions, diags)
+	case "github":
+		PBStructToTF[GitHubOptions](&dst.IdentityProviderGitHub, src.IdentityProviderOptions, diags)
+	case "gitlab":
+		PBStructToTF[GitLabOptions](&dst.IdentityProviderGitLab, src.IdentityProviderOptions, diags)
+	case "google":
+		PBStructToTF[GoogleOptions](&dst.IdentityProviderGoogle, src.IdentityProviderOptions, diags)
+	case "okta":
+		PBStructToTF[OktaOptions](&dst.IdentityProviderOkta, src.IdentityProviderOptions, diags)
+	case "onelogin":
+		PBStructToTF[OneLoginOptions](&dst.IdentityProviderOneLogin, src.IdentityProviderOptions, diags)
+	case "ping":
+		PBStructToTF[PingOptions](&dst.IdentityProviderPing, src.IdentityProviderOptions, diags)
+	default:
+		diags.AddError("invalid identity provider", fmt.Sprintf("unknown identity provider %q", *src.IdentityProvider))
+	}
+}
+
+func IdentityProviderSettingsToPB(
+	ctx context.Context,
+	dst *pb.Settings,
+	src *SettingsModel,
+	diags *diag.Diagnostics,
+) {
+	if !src.IdentityProviderAuth0.IsNull() {
+		setIdpSettings[Auth0Options](ctx, "auth0", dst, src.IdentityProviderAuth0, diags)
+	}
+	if !src.IdentityProviderAzure.IsNull() {
+		setIdpSettings[AzureOptions](ctx, "azure", dst, src.IdentityProviderAzure, diags)
+	}
+	if !src.IdentityProviderCognito.IsNull() {
+		setIdpSettings[CognitoOptions](ctx, "cognito", dst, src.IdentityProviderCognito, diags)
+	}
+	if !src.IdentityProviderGitHub.IsNull() {
+		setIdpSettings[GitHubOptions](ctx, "github", dst, src.IdentityProviderGitHub, diags)
+	}
+	if !src.IdentityProviderGitLab.IsNull() {
+		setIdpSettings[GitLabOptions](ctx, "gitlab", dst, src.IdentityProviderGitLab, diags)
+	}
+	if !src.IdentityProviderGoogle.IsNull() {
+		setIdpSettings[GoogleOptions](ctx, "google", dst, src.IdentityProviderGoogle, diags)
+	}
+	if !src.IdentityProviderOkta.IsNull() {
+		setIdpSettings[OktaOptions](ctx, "okta", dst, src.IdentityProviderOkta, diags)
+	}
+	if !src.IdentityProviderOneLogin.IsNull() {
+		setIdpSettings[OneLoginOptions](ctx, "onelogin", dst, src.IdentityProviderOneLogin, diags)
+	}
+	if !src.IdentityProviderPing.IsNull() {
+		setIdpSettings[PingOptions](ctx, "ping", dst, src.IdentityProviderPing, diags)
+	}
+}
+
+func setIdpSettings[T any](
+	ctx context.Context,
+	name string,
+	dst *pb.Settings,
+	src types.Object,
+	diags *diag.Diagnostics,
+) {
+	var v T
+	d := src.As(ctx, &v, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    false,
+		UnhandledUnknownAsEmpty: false,
+	})
+	diags.Append(d...)
+	if d.HasError() {
+		return
+	}
+	dst.IdentityProvider = &name
+	s, err := GoStructToPB(v)
+	if err != nil {
+		diags.AddError("failed to convert idp settings", fmt.Sprintf("type %T: %s", v, err))
+		return
+	}
+	dst.IdentityProviderOptions = s
+}

--- a/internal/provider/settings_model.go
+++ b/internal/provider/settings_model.go
@@ -44,8 +44,15 @@ type SettingsModel struct {
 	GRPCAddress                                       types.String  `tfsdk:"grpc_address"`
 	GRPCInsecure                                      types.Bool    `tfsdk:"grpc_insecure"`
 	HTTPRedirectAddr                                  types.String  `tfsdk:"http_redirect_addr"`
-	IdentityProvider                                  types.String  `tfsdk:"identity_provider"`
-	IdentityProviderOptions                           types.Map     `tfsdk:"identity_provider_options"`
+	IdentityProviderAuth0                             types.Object  `tfsdk:"identity_provider_auth0"`
+	IdentityProviderAzure                             types.Object  `tfsdk:"identity_provider_azure"`
+	IdentityProviderCognito                           types.Object  `tfsdk:"identity_provider_cognito"`
+	IdentityProviderGitHub                            types.Object  `tfsdk:"identity_provider_github"`
+	IdentityProviderGitLab                            types.Object  `tfsdk:"identity_provider_gitlab"`
+	IdentityProviderGoogle                            types.Object  `tfsdk:"identity_provider_google"`
+	IdentityProviderOkta                              types.Object  `tfsdk:"identity_provider_okta"`
+	IdentityProviderOneLogin                          types.Object  `tfsdk:"identity_provider_onelogin"`
+	IdentityProviderPing                              types.Object  `tfsdk:"identity_provider_ping"`
 	IdentityProviderRefreshInterval                   types.String  `tfsdk:"identity_provider_refresh_interval"`
 	IdentityProviderRefreshTimeout                    types.String  `tfsdk:"identity_provider_refresh_timeout"`
 	IdpClientID                                       types.String  `tfsdk:"idp_client_id"`
@@ -122,7 +129,7 @@ func ConvertSettingsToPB(
 	pbSettings.GrpcAddress = src.GRPCAddress.ValueStringPointer()
 	pbSettings.GrpcInsecure = src.GRPCInsecure.ValueBoolPointer()
 	pbSettings.HttpRedirectAddr = src.HTTPRedirectAddr.ValueStringPointer()
-	pbSettings.IdentityProvider = src.IdentityProvider.ValueStringPointer()
+	IdentityProviderSettingsToPB(ctx, pbSettings, src, &diagnostics)
 	ToDuration(&pbSettings.IdentityProviderRefreshInterval, src.IdentityProviderRefreshInterval, "identity_provider_refresh_interval", &diagnostics)
 	ToDuration(&pbSettings.IdentityProviderRefreshTimeout, src.IdentityProviderRefreshTimeout, "identity_provider_refresh_timeout", &diagnostics)
 	pbSettings.IdpClientId = src.IdpClientID.ValueStringPointer()
@@ -200,7 +207,7 @@ func ConvertSettingsFromPB(
 	dst.GRPCAddress = types.StringPointerValue(src.GrpcAddress)
 	dst.GRPCInsecure = types.BoolPointerValue(src.GrpcInsecure)
 	dst.HTTPRedirectAddr = types.StringPointerValue(src.HttpRedirectAddr)
-	dst.IdentityProvider = types.StringPointerValue(src.IdentityProvider)
+	IdentityProviderSettingsFromPB(dst, src, &diagnostics)
 	dst.IdentityProviderRefreshInterval = FromDuration(src.IdentityProviderRefreshInterval)
 	dst.IdentityProviderRefreshTimeout = FromDuration(src.IdentityProviderRefreshTimeout)
 	dst.IdpClientID = types.StringPointerValue(src.IdpClientId)

--- a/internal/provider/settings_schema.go
+++ b/internal/provider/settings_schema.go
@@ -3,12 +3,38 @@ package provider
 import (
 	_ "embed"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 //go:embed help/settings.md
 var settingsResourceHelp string
+
+func idpOneOf(name string) []validator.Object {
+	var exprs []path.Expression
+	for _, n := range []string{
+		"identity_provider_auth0",
+		"identity_provider_azure",
+		"identity_provider_cognito",
+		"identity_provider_github",
+		"identity_provider_gitlab",
+		"identity_provider_google",
+		"identity_provider_okta",
+		"identity_provider_onelogin",
+		"identity_provider_ping",
+	} {
+		if n == name {
+			continue
+		}
+		exprs = append(exprs, path.MatchRelative().AtParent().AtName(n))
+	}
+	return []validator.Object{
+		objectvalidator.ConflictsWith(exprs...),
+	}
+}
 
 var SettingsResourceSchema = schema.Schema{
 	MarkdownDescription: settingsResourceHelp,
@@ -269,14 +295,150 @@ var SettingsResourceSchema = schema.Schema{
 			Optional:    true,
 			Description: "Error message first paragraph",
 		},
-		"identity_provider": schema.StringAttribute{
+		"identity_provider_auth0": schema.SingleNestedAttribute{
 			Optional:    true,
-			Description: "Identity provider",
+			Description: "Auth0 directory sync options",
+			Validators:  idpOneOf("identity_provider_auth0"),
+			Attributes: map[string]schema.Attribute{
+				"client_id": schema.StringAttribute{
+					Required: true,
+				},
+				"client_secret": schema.StringAttribute{
+					Required:  true,
+					Sensitive: true,
+				},
+				"domain": schema.StringAttribute{
+					Required: true,
+				},
+			},
 		},
-		"identity_provider_options": schema.MapAttribute{
-			ElementType: types.StringType,
+		"identity_provider_azure": schema.SingleNestedAttribute{
 			Optional:    true,
-			Description: "Identity provider options",
+			Description: "Azure EntraID directory sync options",
+			Validators:  idpOneOf("identity_provider_azure"),
+			Attributes: map[string]schema.Attribute{
+				"client_id": schema.StringAttribute{
+					Required: true,
+				},
+				"client_secret": schema.StringAttribute{
+					Required:  true,
+					Sensitive: true,
+				},
+				"directory_id": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+		"identity_provider_cognito": schema.SingleNestedAttribute{
+			Optional:    true,
+			Description: "Cognito directory sync options",
+			Validators:  idpOneOf("identity_provider_cognito"),
+			Attributes: map[string]schema.Attribute{
+				"access_key_id": schema.StringAttribute{
+					Required: true,
+				},
+				"region": schema.StringAttribute{
+					Required: true,
+				},
+				"secret_access_key": schema.StringAttribute{
+					Required:  true,
+					Sensitive: true,
+				},
+				"session_token": schema.StringAttribute{
+					Required:  true,
+					Sensitive: true,
+				},
+				"user_pool_id": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+		"identity_provider_github": schema.SingleNestedAttribute{
+			Optional:    true,
+			Description: "GitHub directory sync options",
+			Validators:  idpOneOf("identity_provider_github"),
+			Attributes: map[string]schema.Attribute{
+				"username": schema.StringAttribute{
+					Required: true,
+				},
+				"personal_access_token": schema.StringAttribute{
+					Required:  true,
+					Sensitive: true,
+				},
+			},
+		},
+		"identity_provider_gitlab": schema.SingleNestedAttribute{
+			Optional:    true,
+			Description: "GitLab directory sync options",
+			Validators:  idpOneOf("identity_provider_gitlab"),
+			Attributes: map[string]schema.Attribute{
+				"private_token": schema.StringAttribute{
+					Required:  true,
+					Sensitive: true,
+				},
+			},
+		},
+		"identity_provider_google": schema.SingleNestedAttribute{
+			Optional:    true,
+			Description: "Google directory sync options",
+			Validators:  idpOneOf("identity_provider_google"),
+			Attributes: map[string]schema.Attribute{
+				"impersonate_user": schema.StringAttribute{
+					Optional: true,
+				},
+				"json_key": schema.StringAttribute{
+					Required:  true,
+					Sensitive: true,
+				},
+				"url": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+		"identity_provider_okta": schema.SingleNestedAttribute{
+			Optional:    true,
+			Description: "Okta directory sync options",
+			Validators:  idpOneOf("identity_provider_okta"),
+			Attributes: map[string]schema.Attribute{
+				"api_key": schema.StringAttribute{
+					Required:  true,
+					Sensitive: true,
+				},
+				"url": schema.StringAttribute{
+					Required: true,
+				},
+			},
+		},
+		"identity_provider_onelogin": schema.SingleNestedAttribute{
+			Optional:    true,
+			Description: "OneLogin directory sync options",
+			Validators:  idpOneOf("identity_provider_onelogin"),
+			Attributes: map[string]schema.Attribute{
+				"client_id": schema.StringAttribute{
+					Required: true,
+				},
+				"client_secret": schema.StringAttribute{
+					Required:  true,
+					Sensitive: true,
+				},
+			},
+		},
+		"identity_provider_ping": schema.SingleNestedAttribute{
+			Optional:    true,
+			Description: "Ping directory sync options",
+			Validators:  idpOneOf("identity_provider_ping"),
+			Attributes: map[string]schema.Attribute{
+				"client_id": schema.StringAttribute{
+					Required: true,
+				},
+				"client_secret": schema.StringAttribute{
+					Required:  true,
+					Sensitive: true,
+				},
+				"environment_id": schema.StringAttribute{
+					Required: true,
+				},
+			},
 		},
 		"identity_provider_refresh_interval": schema.StringAttribute{
 			Optional:    true,


### PR DESCRIPTION
Adds IDP settings. 

Instead of having `identity_provider_name` and dynamic `identity_provider_options` we would have blocks of typed params:

```terraform
resource "pomerium_settings" "settings" {
  identity_provider_okta = {
    api_key = "key"
    url     = "http://localhost"
  }
}
```

https://linear.app/pomerium/issue/ENG-1731/configure-idp-directory-sync-via-terraform