### PR TITLE
handle resource not found

### DIFF
--- a/internal/provider/keychain.go
+++ b/internal/provider/keychain.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	client "github.com/pomerium/enterprise-client-go"
 	"github.com/pomerium/enterprise-client-go/pb"
@@ -131,6 +133,10 @@ func (r *KeyChainResource) Read(ctx context.Context, req resource.ReadRequest, r
 		Id: state.ID.ValueString(),
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading key pair", err.Error())
 		return
 	}

--- a/internal/provider/namespace.go
+++ b/internal/provider/namespace.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	client "github.com/pomerium/enterprise-client-go"
 	"github.com/pomerium/enterprise-client-go/pb"
@@ -108,6 +110,10 @@ func (r *NamespaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 		Id: state.ID.ValueString(),
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading namespace", err.Error())
 		return
 	}

--- a/internal/provider/namespace_permission.go
+++ b/internal/provider/namespace_permission.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	client "github.com/pomerium/enterprise-client-go"
 	"github.com/pomerium/enterprise-client-go/pb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 //go:embed help/namespace_permissions.md
@@ -118,6 +120,10 @@ func (r *NamespacePermissionResource) Read(ctx context.Context, req resource.Rea
 		Id: state.ID.ValueString(),
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("failed to read namespace permission", err.Error())
 		return
 	}

--- a/internal/provider/policy.go
+++ b/internal/provider/policy.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	client "github.com/pomerium/enterprise-client-go"
 	"github.com/pomerium/enterprise-client-go/pb"
@@ -150,6 +152,10 @@ func (r *PolicyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		Id: state.ID.ValueString(),
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading policy", err.Error())
 		return
 	}

--- a/internal/provider/route.go
+++ b/internal/provider/route.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	client "github.com/pomerium/enterprise-client-go"
 	"github.com/pomerium/enterprise-client-go/pb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -256,6 +258,10 @@ func (r *RouteResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		Id: state.ID.ValueString(),
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("get route", err.Error())
 		return
 	}

--- a/internal/provider/service_account.go
+++ b/internal/provider/service_account.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	client "github.com/pomerium/enterprise-client-go"
 	"github.com/pomerium/enterprise-client-go/pb"
@@ -131,6 +133,10 @@ func (r *ServiceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 		Id: state.ID.ValueString(),
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading service account", err.Error())
 		return
 	}


### PR DESCRIPTION
if a resource was created and exists in a plan, but was deleted outside of terraform, it would return an error during `Read`.
this PR handles NotFound response and removes the resource from plan, so that it would get re-created. 

Fixes https://linear.app/pomerium/issue/ENG-1782/provider-doesnt-handle-route-deletion-correctly

