### PR TITLE
service-accounts: add jwts, better handling of user id

### DIFF
--- a/internal/provider/service_account.go
+++ b/internal/provider/service_account.go
@@ -79,7 +79,7 @@ func (r *ServiceAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 			"jwt": schema.StringAttribute{
 				Computed:    true,
 				Sensitive:   true,
-				Description: "The Service Account JWT used for authentication. This is only populated when creating a new key.",
+				Description: "The Service Account JWT used for authentication. This is only populated when creating a new service account.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
Add a `jwt` property to the output of service accounts. This is only populated on creation but will be stored in the terraform state.

User IDs are somewhat confusing with service accounts. There are two cases:

1. If the `namespace_id` is null when `AddPomeriumServiceAccount` is called the user ID of the service account will be set to what the user enters.
2. If the `namespace_id` is **not** null when `AddPomeriumServiceAccount` is called the user ID will have `@{NAMESPACE-ID}.pomerium` added to it.

To reflect this behavior, use the `name` field, which doesn't exist in the enterprise console, to represent the user ID without the added `@...`.