### PR TITLE
policy: set defaults

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -16,7 +16,18 @@ provider "pomerium" {
 
 locals {
   root_namespace_id = "9d8dbd2c-8cce-4e66-9c1f-c490b4a07243"
+
+  any_authenticated_user_ppl = {
+    allow = {
+      and = [
+        {
+          authenticated_user = true
+        }
+      ]
+    }
+  }
 }
+
 # Create resources
 resource "pomerium_namespace" "test_namespace" {
   name      = "test-namespace"
@@ -36,16 +47,20 @@ resource "pomerium_settings" "settings" {
     api_key = "key"
     url     = "http://localhost"
   }
+
+  log_level       = "info"
+  proxy_log_level = "info"
+  # tracing_provider                  = "jaeger"
+  # tracing_sample_rate               = 1
+  # tracing_jaeger_collector_endpoint = "http://localhost:14268/api/traces"
+  # tracing_jaeger_agent_endpoint     = "localhost:6831"
+
   timeout_idle = "5m"
 }
 
 resource "pomerium_policy" "test_policy" {
   name         = "test-policy"
   namespace_id = pomerium_namespace.test_namespace.id
-  description  = "test policy"
-  enforced     = false
-  explanation  = "test policy explanation"
-  remediation  = "test policy remediation"
   ppl          = <<EOF
 - allow:
     and:

--- a/internal/provider/policy.go
+++ b/internal/provider/policy.go
@@ -7,7 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -56,6 +58,8 @@ func (r *PolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"description": schema.StringAttribute{
 				Description: "Description of the policy.",
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"name": schema.StringAttribute{
 				Description: "Name of the policy.",
@@ -78,14 +82,20 @@ func (r *PolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"enforced": schema.BoolAttribute{
 				Description: "Whether the policy is enforced within the namespace hierarchy.",
 				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 			"explanation": schema.StringAttribute{
 				Description: "Explanation of the policy.",
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"remediation": schema.StringAttribute{
 				Description: "Remediation of the policy.",
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 		},
 	}

--- a/internal/provider/policy_types.go
+++ b/internal/provider/policy_types.go
@@ -67,7 +67,7 @@ func (PolicyLanguageType) ValueFromString(
 	var diag diag.Diagnostics
 	v, err := PolicyLanguageType{}.Parse(in)
 	if err != nil {
-		diag.AddError("failed to parse PPL", err.Error())
+		diag.AddError("failed to parse PPL", err.Error()+">>"+in.ValueString()+"<<")
 		return nil, diag
 	}
 	return v, nil


### PR DESCRIPTION
Policy protobuf does not use `optional` on Policy properties, which makes them get Go default values. 
That makes terraform think on next apply the resource would need to be reconciled again.

This PR sets default values on such properties of the Policy resource to prevent that. 

Fixes https://linear.app/pomerium/issue/ENG-1930/terraformprovider-sometimes-theres-a-diff-of-policy-reported

