### PR TITLE
ppl: handle unknown state

### DIFF
--- a/internal/provider/policy_types_test.go
+++ b/internal/provider/policy_types_test.go
@@ -35,7 +35,11 @@ func TestPolicyTypes(t *testing.T) {
 		},
 		"null": {
 			in:       tftypes.NewValue(tftypes.String, nil),
-			expected: provider.PolicyLanguage{},
+			expected: provider.PolicyLanguage{StringValue: basetypes.NewStringNull()},
+		},
+		"unknown": {
+			in:       tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expected: provider.PolicyLanguage{StringValue: basetypes.NewStringUnknown()},
 		},
 	}
 	for name, testCase := range testCases {


### PR DESCRIPTION
If PPL block was referencing some values that were unknown, it still tried to parse the PPL. Instead, it should return an unknown state as well.
Similarly for null values. 

Fixes https://linear.app/pomerium/issue/ENG-1936

