### PR TITLE
service-accounts: move jwt from shared model

### DIFF
--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -19,7 +19,6 @@ type ServiceAccountModel struct {
 	Description types.String `tfsdk:"description"`
 	UserID      types.String `tfsdk:"user_id"`
 	ExpiresAt   types.String `tfsdk:"expires_at"`
-	JWT         types.String `tfsdk:"jwt"`
 }
 
 func ConvertServiceAccountToPB(_ context.Context, src *ServiceAccountResourceModel) (*pb.PomeriumServiceAccount, diag.Diagnostics) {
@@ -42,7 +41,7 @@ func ConvertServiceAccountToPB(_ context.Context, src *ServiceAccountResourceMod
 	return pbServiceAccount, diags
 }
 
-func ConvertServiceAccountFromPB(dst *ServiceAccountResourceModel, src *pb.PomeriumServiceAccount) diag.Diagnostics {
+func ConvertServiceAccountFromPB(dst *ServiceAccountModel, src *pb.PomeriumServiceAccount) diag.Diagnostics {
 	var diagnostics diag.Diagnostics
 
 	dst.ID = types.StringValue(src.Id)

--- a/internal/provider/service_account.go
+++ b/internal/provider/service_account.go
@@ -31,7 +31,10 @@ type ServiceAccountResource struct {
 	client *client.Client
 }
 
-type ServiceAccountResourceModel = ServiceAccountModel
+type ServiceAccountResourceModel struct {
+	ServiceAccountModel
+	JWT types.String `tfsdk:"jwt"`
+}
 
 func (r *ServiceAccountResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_service_account"
@@ -127,7 +130,7 @@ func (r *ServiceAccountResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	diags = ConvertServiceAccountFromPB(&plan, respServiceAccount.ServiceAccount)
+	diags = ConvertServiceAccountFromPB(&plan.ServiceAccountModel, respServiceAccount.ServiceAccount)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -163,7 +166,7 @@ func (r *ServiceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	diags := ConvertServiceAccountFromPB(&state, respServiceAccount.ServiceAccount)
+	diags := ConvertServiceAccountFromPB(&state.ServiceAccountModel, respServiceAccount.ServiceAccount)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/service_accounts_data_source.go
+++ b/internal/provider/service_accounts_data_source.go
@@ -23,7 +23,7 @@ type ServiceAccountsDataSource struct {
 }
 
 type ServiceAccountsDataSourceModel struct {
-	Namespace       types.String          `tfsdk:"namespace"`
+	NamespaceID     types.String          `tfsdk:"namespace_id"`
 	ServiceAccounts []ServiceAccountModel `tfsdk:"service_accounts"`
 }
 
@@ -35,7 +35,7 @@ func (d *ServiceAccountsDataSource) Schema(_ context.Context, _ datasource.Schem
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "List all service accounts",
 		Attributes: map[string]schema.Attribute{
-			"namespace": schema.StringAttribute{
+			"namespace_id": schema.StringAttribute{
 				Optional:    true,
 				Description: "Namespace of the service accounts.",
 			},
@@ -100,7 +100,7 @@ func (d *ServiceAccountsDataSource) Read(ctx context.Context, req datasource.Rea
 	}
 
 	listReq := &pb.ListPomeriumServiceAccountsRequest{
-		Namespace: data.Namespace.ValueString(),
+		Namespace: data.NamespaceID.ValueString(),
 	}
 	serviceAccountsResp, err := d.client.PomeriumServiceAccountService.ListPomeriumServiceAccounts(ctx, listReq)
 	if err != nil {


### PR DESCRIPTION
For service account data sources, the `JWT` field only exists for resources not for the data model, so move it. Also add support for querying by namespace.