### PR TITLE
resources: use sets for properties where order has no significance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: go mod download
       
       - name: Run tests
-        run: go test -v -cover ./internal/provider/...
+        run: make test
       
       - name: Run acceptance tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,10 @@ build:
 
 .PHONY: docs
 docs:
+	@echo "@==> $@"
 	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest generate --provider-dir . -provider-name pomerium
+
+.PHONY: test
+test:
+	@echo "@==> $@"
+	@go test ./internal/provider/...

--- a/example/main.tf
+++ b/example/main.tf
@@ -76,12 +76,30 @@ resource "pomerium_policy" "test_policy" {
   })
 }
 
+resource "pomerium_policy" "test_policy_group" {
+  name         = "group test policy"
+  namespace_id = pomerium_namespace.test_namespace.id
+  ppl = yamlencode({
+    allow = {
+      and = [
+        {
+          groups = {
+            has = "gid-123456"
+          }
+        }
+      ]
+    }
+  })
+}
 resource "pomerium_route" "test_route" {
   name         = "test-route"
   namespace_id = pomerium_namespace.test_namespace.id
   from         = "https://verify-tf.localhost.pomerium.io"
   to           = ["https://verify.pomerium.com"]
-  policies     = [pomerium_policy.test_policy.id]
+  policies = [
+    pomerium_policy.test_policy_group.id,
+    pomerium_policy.test_policy.id,
+  ]
 }
 
 resource "pomerium_key_pair" "test_key_pair" {

--- a/internal/provider/convert_test.go
+++ b/internal/provider/convert_test.go
@@ -49,7 +49,7 @@ func TestFromStringSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := provider.FromStringSlice(tt.input)
+			result := provider.FromStringSliceToList(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -136,24 +136,24 @@ func TestToDuration(t *testing.T) {
 	}
 }
 
-func TestToStringList(t *testing.T) {
+func TestToStringListFromSet(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		name        string
-		input       types.List
+		input       types.Set
 		expectError bool
 		validate    func(*testing.T, *pb.Settings_StringList)
 	}{
 		{
 			name:  "null list",
-			input: types.ListNull(types.StringType),
+			input: types.SetNull(types.StringType),
 			validate: func(t *testing.T, s *pb.Settings_StringList) {
 				assert.Nil(t, s)
 			},
 		},
 		{
 			name:  "empty list",
-			input: types.ListValueMust(types.StringType, []attr.Value{}),
+			input: types.SetValueMust(types.StringType, []attr.Value{}),
 			validate: func(t *testing.T, s *pb.Settings_StringList) {
 				require.NotNil(t, s)
 				assert.Empty(t, s.Values)
@@ -161,7 +161,7 @@ func TestToStringList(t *testing.T) {
 		},
 		{
 			name: "valid list",
-			input: types.ListValueMust(types.StringType, []attr.Value{
+			input: types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("value1"),
 				types.StringValue("value2"),
 			}),
@@ -176,7 +176,7 @@ func TestToStringList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var result *pb.Settings_StringList
 			diagnostics := diag.Diagnostics{}
-			provider.ToStringList(ctx, &result, tt.input, &diagnostics)
+			provider.ToStringListFromSet(ctx, &result, tt.input, &diagnostics)
 
 			if tt.expectError {
 				assert.True(t, diagnostics.HasError())

--- a/internal/provider/convert_test.go
+++ b/internal/provider/convert_test.go
@@ -372,3 +372,324 @@ func TestPBStructToTF(t *testing.T) {
 		})
 	}
 }
+
+func TestFromStringSliceToSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected types.Set
+	}{
+		{
+			name:     "nil slice",
+			input:    nil,
+			expected: types.SetNull(types.StringType),
+		},
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: types.SetValueMust(types.StringType, []attr.Value{}),
+		},
+		{
+			name:  "normal slice",
+			input: []string{"a", "b", "c"},
+			expected: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("b"),
+				types.StringValue("c"),
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.FromStringSliceToSet(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFromStringListToSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *pb.Settings_StringList
+		expected types.Set
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: types.SetNull(types.StringType),
+		},
+		{
+			name:     "empty values",
+			input:    &pb.Settings_StringList{Values: []string{}},
+			expected: types.SetValueMust(types.StringType, []attr.Value{}),
+		},
+		{
+			name:  "with values",
+			input: &pb.Settings_StringList{Values: []string{"x", "y", "z"}},
+			expected: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("x"),
+				types.StringValue("y"),
+				types.StringValue("z"),
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.FromStringListToSet(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFromStringMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected types.Map
+	}{
+		{
+			name:     "nil map",
+			input:    nil,
+			expected: types.MapNull(types.StringType),
+		},
+		{
+			name:     "empty map",
+			input:    map[string]string{},
+			expected: types.MapValueMust(types.StringType, map[string]attr.Value{}),
+		},
+		{
+			name: "populated map",
+			input: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expected: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"key1": types.StringValue("value1"),
+				"key2": types.StringValue("value2"),
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.FromStringMap(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToStringSliceFromSet(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		input    types.Set
+		expected []string
+	}{
+		{
+			name:     "null set",
+			input:    types.SetNull(types.StringType),
+			expected: []string{},
+		},
+		{
+			name:     "empty set",
+			input:    types.SetValueMust(types.StringType, []attr.Value{}),
+			expected: []string{},
+		},
+		{
+			name: "populated set",
+			input: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("b"),
+			}),
+			expected: []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result []string
+			diagnostics := diag.Diagnostics{}
+			provider.ToStringSliceFromSet(ctx, &result, tt.input, &diagnostics)
+			assert.False(t, diagnostics.HasError())
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToByteSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    types.String
+		expected []byte
+	}{
+		{
+			name:     "null string",
+			input:    types.StringNull(),
+			expected: nil,
+		},
+		{
+			name:     "empty string",
+			input:    types.StringValue(""),
+			expected: nil,
+		},
+		{
+			name:     "non-empty string",
+			input:    types.StringValue("hello"),
+			expected: []byte("hello"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.ToByteSlice(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestStringSliceExclude(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		exclude  []string
+		expected []string
+	}{
+		{
+			name:     "exclude none",
+			input:    []string{"a", "b", "c"},
+			exclude:  []string{},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "exclude some",
+			input:    []string{"a", "b", "c"},
+			exclude:  []string{"b"},
+			expected: []string{"a", "c"},
+		},
+		{
+			name:     "exclude all",
+			input:    []string{"a", "b", "c"},
+			exclude:  []string{"a", "b", "c"},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.StringSliceExclude(tt.input, tt.exclude)
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToStringSliceFromList(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		input    types.List
+		expected []string
+	}{
+		{
+			name:     "null list",
+			input:    types.ListNull(types.StringType),
+			expected: []string{},
+		},
+		{
+			name:     "empty list",
+			input:    types.ListValueMust(types.StringType, []attr.Value{}),
+			expected: []string{},
+		},
+		{
+			name: "populated list",
+			input: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("b"),
+			}),
+			expected: []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result []string
+			diagnostics := diag.Diagnostics{}
+			provider.ToStringSliceFromList(ctx, &result, tt.input, &diagnostics)
+			assert.False(t, diagnostics.HasError())
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToStringMap(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		input    types.Map
+		expected map[string]string
+	}{
+		{
+			name:     "null map",
+			input:    types.MapNull(types.StringType),
+			expected: nil, // Changed from empty map to nil to match implementation
+		},
+		{
+			name:     "empty map",
+			input:    types.MapValueMust(types.StringType, map[string]attr.Value{}),
+			expected: map[string]string{},
+		},
+		{
+			name: "populated map",
+			input: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"key1": types.StringValue("value1"),
+				"key2": types.StringValue("value2"),
+			}),
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result map[string]string
+			diagnostics := diag.Diagnostics{}
+			provider.ToStringMap(ctx, &result, tt.input, &diagnostics)
+			assert.False(t, diagnostics.HasError())
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetTFObjectTypes(t *testing.T) {
+	type TestStruct struct {
+		Field1 types.String `tfsdk:"field_one"`
+		Field2 types.String `tfsdk:"field_two"`
+	}
+
+	expected := map[string]attr.Type{
+		"field_one": types.StringType,
+		"field_two": types.StringType,
+	}
+
+	result, err := provider.GetTFObjectTypes[TestStruct]()
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+
+	// Test error cases
+	type InvalidStruct struct {
+		Field1 int `tfsdk:"field_one"` // Invalid type
+	}
+	_, err = provider.GetTFObjectTypes[InvalidStruct]()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported field type")
+
+	type NoTagStruct struct {
+		Field1 types.String // Missing tfsdk tag
+	}
+	_, err = provider.GetTFObjectTypes[NoTagStruct]()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing tfsdk tag")
+}

--- a/internal/provider/pointer_test.go
+++ b/internal/provider/pointer_test.go
@@ -1,0 +1,3 @@
+package provider_test
+
+func P[T any](v T) *T { return &v }

--- a/internal/provider/policy_model.go
+++ b/internal/provider/policy_model.go
@@ -49,7 +49,7 @@ func ConvertPolicyFromPB(dst *PolicyResourceModel, src *pb.Policy) diag.Diagnost
 	dst.Enforced = types.BoolValue(src.Enforced)
 	dst.Explanation = types.StringValue(src.Explanation)
 	dst.Remediation = types.StringValue(src.Remediation)
-	dst.Rego = FromStringSlice(src.Rego)
+	dst.Rego = FromStringSliceToList(src.Rego)
 	ppl, err := PolicyLanguageType{}.Parse(types.StringValue(src.Ppl))
 	if err != nil {
 		diagnostics.AddError("converting PPL", err.Error())

--- a/internal/provider/route.go
+++ b/internal/provider/route.go
@@ -59,7 +59,7 @@ func (r *RouteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Description: "From URL.",
 				Required:    true,
 			},
-			"to": schema.ListAttribute{
+			"to": schema.SetAttribute{
 				ElementType: types.StringType,
 				Description: "To URLs.",
 				Required:    true,
@@ -68,7 +68,7 @@ func (r *RouteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Description: "ID of the namespace the route belongs to.",
 				Required:    true,
 			},
-			"policies": schema.ListAttribute{
+			"policies": schema.SetAttribute{
 				ElementType: types.StringType,
 				Description: "List of policy IDs associated with the route.",
 				Optional:    true,
@@ -163,7 +163,7 @@ func (r *RouteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Description: "Set request headers.",
 				Optional:    true,
 			},
-			"remove_request_headers": schema.ListAttribute{
+			"remove_request_headers": schema.SetAttribute{
 				ElementType: types.StringType,
 				Description: "Remove request headers.",
 				Optional:    true,

--- a/internal/provider/route_model.go
+++ b/internal/provider/route_model.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pomerium/enterprise-client-go/pb"
@@ -15,9 +14,9 @@ type RouteModel struct {
 	ID                               types.String         `tfsdk:"id"`
 	Name                             types.String         `tfsdk:"name"`
 	From                             types.String         `tfsdk:"from"`
-	To                               types.List           `tfsdk:"to"`
+	To                               types.Set            `tfsdk:"to"`
 	NamespaceID                      types.String         `tfsdk:"namespace_id"`
-	Policies                         types.List           `tfsdk:"policies"`
+	Policies                         types.Set            `tfsdk:"policies"`
 	StatName                         types.String         `tfsdk:"stat_name"`
 	Prefix                           types.String         `tfsdk:"prefix"`
 	Path                             types.String         `tfsdk:"path"`
@@ -39,7 +38,7 @@ type RouteModel struct {
 	TLSDownstreamServerName          types.String         `tfsdk:"tls_downstream_server_name"`
 	TLSUpstreamAllowRenegotiation    types.Bool           `tfsdk:"tls_upstream_allow_renegotiation"`
 	SetRequestHeaders                types.Map            `tfsdk:"set_request_headers"`
-	RemoveRequestHeaders             types.List           `tfsdk:"remove_request_headers"`
+	RemoveRequestHeaders             types.Set            `tfsdk:"remove_request_headers"`
 	SetResponseHeaders               types.Map            `tfsdk:"set_response_headers"`
 	PreserveHostHeader               types.Bool           `tfsdk:"preserve_host_header"`
 	PassIdentityHeaders              types.Bool           `tfsdk:"pass_identity_headers"`
@@ -81,7 +80,7 @@ func ConvertRouteToPB(
 	pbRoute.TlsDownstreamServerName = src.TLSDownstreamServerName.ValueStringPointer()
 	pbRoute.TlsUpstreamAllowRenegotiation = src.TLSUpstreamAllowRenegotiation.ValueBoolPointer()
 	ToStringMap(ctx, &pbRoute.SetRequestHeaders, src.SetRequestHeaders, &diagnostics)
-	ToStringSlice(ctx, &pbRoute.RemoveRequestHeaders, src.RemoveRequestHeaders, &diagnostics)
+	ToStringSliceFromSet(ctx, &pbRoute.RemoveRequestHeaders, src.RemoveRequestHeaders, &diagnostics)
 	ToStringMap(ctx, &pbRoute.SetResponseHeaders, src.SetResponseHeaders, &diagnostics)
 	pbRoute.PreserveHostHeader = src.PreserveHostHeader.ValueBoolPointer()
 	pbRoute.PassIdentityHeaders = src.PassIdentityHeaders.ValueBoolPointer()
@@ -110,14 +109,8 @@ func ConvertRouteFromPB(
 	dst.Name = types.StringValue(src.Name)
 	dst.From = types.StringValue(src.From)
 	dst.NamespaceID = types.StringValue(src.NamespaceId)
-
-	toList := make([]attr.Value, len(src.To))
-	for i, v := range src.To {
-		toList[i] = types.StringValue(v)
-	}
-	dst.To = types.ListValueMust(types.StringType, toList)
-
-	dst.Policies = FromStringSlice(StringSliceExclude(src.PolicyIds, src.EnforcedPolicyIds))
+	dst.To = FromStringSliceToSet(src.To)
+	dst.Policies = FromStringSliceToSet(StringSliceExclude(src.PolicyIds, src.EnforcedPolicyIds))
 	dst.StatName = types.StringValue(src.StatName)
 	dst.Prefix = types.StringPointerValue(src.Prefix)
 	dst.Path = types.StringPointerValue(src.Path)
@@ -139,7 +132,7 @@ func ConvertRouteFromPB(
 	dst.TLSDownstreamServerName = types.StringPointerValue(src.TlsDownstreamServerName)
 	dst.TLSUpstreamAllowRenegotiation = types.BoolPointerValue(src.TlsUpstreamAllowRenegotiation)
 	dst.SetRequestHeaders = FromStringMap(src.SetRequestHeaders)
-	dst.RemoveRequestHeaders = FromStringSlice(src.RemoveRequestHeaders)
+	dst.RemoveRequestHeaders = FromStringSliceToSet(src.RemoveRequestHeaders)
 	dst.SetResponseHeaders = FromStringMap(src.SetResponseHeaders)
 	dst.PreserveHostHeader = types.BoolPointerValue(src.PreserveHostHeader)
 	dst.PassIdentityHeaders = types.BoolPointerValue(src.PassIdentityHeaders)

--- a/internal/provider/route_test.go
+++ b/internal/provider/route_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pomerium/enterprise-client-go/pb"
 	"github.com/pomerium/enterprise-terraform-provider/internal/provider"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestConvertRoute(t *testing.T) {
@@ -18,35 +19,133 @@ func TestConvertRoute(t *testing.T) {
 	t.Run("pb to model", func(t *testing.T) {
 		t.Parallel()
 
-		// Test conversion from pb to model
-		route := &pb.Route{
-			Id:   "route-id",
-			Name: "route-name",
-			From: "from",
-			To:   []string{"to"},
+		input := &pb.Route{
+			Id:                  "route-id",
+			Name:                "route-name",
+			From:                "from",
+			To:                  []string{"to1", "to2"},
+			Prefix:              P("/api"),
+			Path:                P("/v1"),
+			PassIdentityHeaders: P(true),
+			SetRequestHeaders: map[string]string{
+				"X-Custom": "value",
+			},
+			RemoveRequestHeaders: []string{"Remove-Me"},
+			NamespaceId:          "namespace-1",
+			StatName:             "stats-name",
+			PolicyIds:            []string{"policy-1", "policy-2"},
+			SetResponseHeaders: map[string]string{
+				"X-Response": "value",
+			},
+			ShowErrorDetails: true,
 		}
 
-		var plan provider.RouteResourceModel
-		diag := provider.ConvertRouteFromPB(&plan, route)
+		var actual provider.RouteResourceModel
+		diag := provider.ConvertRouteFromPB(&actual, input)
 		require.False(t, diag.HasError(), diag.Errors())
+
+		expected := provider.RouteResourceModel{
+			ID:                  types.StringValue("route-id"),
+			Name:                types.StringValue("route-name"),
+			From:                types.StringValue("from"),
+			Prefix:              types.StringValue("/api"),
+			Path:                types.StringValue("/v1"),
+			PassIdentityHeaders: types.BoolValue(true),
+			To: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("to1"),
+				types.StringValue("to2"),
+			}),
+			SetRequestHeaders: types.MapValueMust(
+				types.StringType,
+				map[string]attr.Value{
+					"X-Custom": types.StringValue("value"),
+				},
+			),
+			RemoveRequestHeaders: types.SetValueMust(
+				types.StringType,
+				[]attr.Value{types.StringValue("Remove-Me")},
+			),
+			NamespaceID: types.StringValue("namespace-1"),
+			StatName:    types.StringValue("stats-name"),
+			Policies: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("policy-1"),
+				types.StringValue("policy-2"),
+			}),
+			SetResponseHeaders: types.MapValueMust(
+				types.StringType,
+				map[string]attr.Value{
+					"X-Response": types.StringValue("value"),
+				},
+			),
+			ShowErrorDetails: types.BoolValue(true),
+		}
+
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Errorf("unexpected difference: %s", diff)
+		}
 	})
 
 	t.Run("model to pb", func(t *testing.T) {
 		t.Parallel()
 
-		// Test conversion from model to pb
-		plan := provider.RouteResourceModel{
-			From: types.StringValue("from"),
-			To:   types.SetValueMust(types.StringType, []attr.Value{types.StringValue("to")}),
-			Name: types.StringValue("route-name"),
+		input := provider.RouteResourceModel{
 			ID:   types.StringValue("route-id"),
+			Name: types.StringValue("route-name"),
+			From: types.StringValue("from"),
+			To: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("to1"),
+				types.StringValue("to2"),
+			}),
+			Prefix:              types.StringValue("/api"),
+			Path:                types.StringValue("/v1"),
+			PassIdentityHeaders: types.BoolValue(true),
+			SetRequestHeaders: types.MapValueMust(
+				types.StringType,
+				map[string]attr.Value{
+					"X-Custom": types.StringValue("value"),
+				},
+			),
+			RemoveRequestHeaders: types.SetValueMust(
+				types.StringType,
+				[]attr.Value{types.StringValue("Remove-Me")},
+			),
+			NamespaceID: types.StringValue("namespace-1"),
+			StatName:    types.StringValue("stats-name"),
+			Policies: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("policy-1"),
+				types.StringValue("policy-2"),
+			}),
+			SetResponseHeaders: types.MapValueMust(
+				types.StringType,
+				map[string]attr.Value{
+					"X-Response": types.StringValue("value"),
+				},
+			),
+			ShowErrorDetails: types.BoolValue(true),
 		}
 
-		route, diag := provider.ConvertRouteToPB(context.Background(), &plan)
+		actual, diag := provider.ConvertRouteToPB(context.Background(), &input)
 		require.False(t, diag.HasError(), diag.Errors())
-		assert.Equal(t, "route-id", route.Id)
-		assert.Equal(t, "route-name", route.Name)
-		assert.Equal(t, "from", route.From)
-		assert.Equal(t, []string{"to"}, route.To)
+
+		expected := &pb.Route{
+			Id:                   "route-id",
+			Name:                 "route-name",
+			From:                 "from",
+			To:                   []string{"to1", "to2"},
+			Prefix:               P("/api"),
+			Path:                 P("/v1"),
+			PassIdentityHeaders:  P(true),
+			SetRequestHeaders:    map[string]string{"X-Custom": "value"},
+			RemoveRequestHeaders: []string{"Remove-Me"},
+			NamespaceId:          "namespace-1",
+			StatName:             "stats-name",
+			PolicyIds:            []string{"policy-1", "policy-2"},
+			SetResponseHeaders:   map[string]string{"X-Response": "value"},
+			ShowErrorDetails:     true,
+		}
+
+		if diff := cmp.Diff(expected, actual, protocmp.Transform()); diff != "" {
+			t.Errorf("unexpected difference: %s", diff)
+		}
 	})
 }

--- a/internal/provider/route_test.go
+++ b/internal/provider/route_test.go
@@ -37,7 +37,7 @@ func TestConvertRoute(t *testing.T) {
 		// Test conversion from model to pb
 		plan := provider.RouteResourceModel{
 			From: types.StringValue("from"),
-			To:   types.ListValueMust(types.StringType, []attr.Value{types.StringValue("to")}),
+			To:   types.SetValueMust(types.StringType, []attr.Value{types.StringValue("to")}),
 			Name: types.StringValue("route-name"),
 			ID:   types.StringValue("route-id"),
 		}

--- a/internal/provider/settings_model.go
+++ b/internal/provider/settings_model.go
@@ -10,11 +10,11 @@ import (
 )
 
 type SettingsModel struct {
-	AccessLogFields                                   types.List           `tfsdk:"access_log_fields"`
+	AccessLogFields                                   types.Set            `tfsdk:"access_log_fields"`
 	Address                                           types.String         `tfsdk:"address"`
 	AuthenticateCallbackPath                          types.String         `tfsdk:"authenticate_callback_path"`
 	AuthenticateServiceURL                            types.String         `tfsdk:"authenticate_service_url"`
-	AuthorizeLogFields                                types.List           `tfsdk:"authorize_log_fields"`
+	AuthorizeLogFields                                types.Set            `tfsdk:"authorize_log_fields"`
 	AuthorizeServiceURL                               types.String         `tfsdk:"authorize_service_url"`
 	Autocert                                          types.Bool           `tfsdk:"autocert"`
 	AutocertDir                                       types.String         `tfsdk:"autocert_dir"`
@@ -73,7 +73,7 @@ type SettingsModel struct {
 	PrimaryColor                                      types.String         `tfsdk:"primary_color"`
 	ProxyLogLevel                                     types.String         `tfsdk:"proxy_log_level"`
 	RequestParams                                     types.Map            `tfsdk:"request_params"`
-	Scopes                                            types.List           `tfsdk:"scopes"`
+	Scopes                                            types.Set            `tfsdk:"scopes"`
 	SecondaryColor                                    types.String         `tfsdk:"secondary_color"`
 	SetResponseHeaders                                types.Map            `tfsdk:"set_response_headers"`
 	SkipXFFAppend                                     types.Bool           `tfsdk:"skip_xff_append"`
@@ -89,11 +89,11 @@ func ConvertSettingsToPB(
 	var diagnostics diag.Diagnostics
 	pbSettings := &pb.Settings{}
 
-	ToStringList(ctx, &pbSettings.AccessLogFields, src.AccessLogFields, &diagnostics)
+	ToStringListFromSet(ctx, &pbSettings.AccessLogFields, src.AccessLogFields, &diagnostics)
 	pbSettings.Address = src.Address.ValueStringPointer()
 	pbSettings.AuthenticateCallbackPath = src.AuthenticateCallbackPath.ValueStringPointer()
 	pbSettings.AuthenticateServiceUrl = src.AuthenticateServiceURL.ValueStringPointer()
-	ToStringList(ctx, &pbSettings.AuthorizeLogFields, src.AuthorizeLogFields, &diagnostics)
+	ToStringListFromSet(ctx, &pbSettings.AuthorizeLogFields, src.AuthorizeLogFields, &diagnostics)
 	pbSettings.AuthorizeServiceUrl = src.AuthorizeServiceURL.ValueStringPointer()
 	pbSettings.Autocert = src.Autocert.ValueBoolPointer()
 	pbSettings.AutocertDir = src.AutocertDir.ValueStringPointer()
@@ -144,7 +144,7 @@ func ConvertSettingsToPB(
 	pbSettings.PrimaryColor = src.PrimaryColor.ValueStringPointer()
 	pbSettings.ProxyLogLevel = src.ProxyLogLevel.ValueStringPointer()
 	ToStringMap(ctx, &pbSettings.RequestParams, src.RequestParams, &diagnostics)
-	ToStringSlice(ctx, &pbSettings.Scopes, src.Scopes, &diagnostics)
+	ToStringSliceFromSet(ctx, &pbSettings.Scopes, src.Scopes, &diagnostics)
 	pbSettings.SecondaryColor = src.SecondaryColor.ValueStringPointer()
 	ToStringMap(ctx, &pbSettings.SetResponseHeaders, src.SetResponseHeaders, &diagnostics)
 	pbSettings.SkipXffAppend = src.SkipXFFAppend.ValueBoolPointer()
@@ -161,11 +161,11 @@ func ConvertSettingsFromPB(
 ) diag.Diagnostics {
 	var diagnostics diag.Diagnostics
 
-	dst.AccessLogFields = FromStringList(src.AccessLogFields)
+	dst.AccessLogFields = FromStringListToSet(src.AccessLogFields)
 	dst.Address = types.StringPointerValue(src.Address)
 	dst.AuthenticateCallbackPath = types.StringPointerValue(src.AuthenticateCallbackPath)
 	dst.AuthenticateServiceURL = types.StringPointerValue(src.AuthenticateServiceUrl)
-	dst.AuthorizeLogFields = FromStringList(src.AuthorizeLogFields)
+	dst.AuthorizeLogFields = FromStringListToSet(src.AuthorizeLogFields)
 	dst.AuthorizeServiceURL = types.StringPointerValue(src.AuthorizeServiceUrl)
 	dst.Autocert = types.BoolPointerValue(src.Autocert)
 	dst.AutocertDir = types.StringPointerValue(src.AutocertDir)
@@ -216,7 +216,7 @@ func ConvertSettingsFromPB(
 	dst.PrimaryColor = types.StringPointerValue(src.PrimaryColor)
 	dst.ProxyLogLevel = types.StringPointerValue(src.ProxyLogLevel)
 	dst.RequestParams = FromStringMap(src.RequestParams)
-	dst.Scopes = FromStringSlice(src.Scopes)
+	dst.Scopes = FromStringSliceToSet(src.Scopes)
 	dst.SecondaryColor = types.StringPointerValue(src.SecondaryColor)
 	dst.SetResponseHeaders = FromStringMap(src.SetResponseHeaders)
 	dst.SkipXFFAppend = types.BoolPointerValue(src.SkipXffAppend)

--- a/internal/provider/settings_schema.go
+++ b/internal/provider/settings_schema.go
@@ -139,7 +139,7 @@ var SettingsResourceSchema = schema.Schema{
 			Optional:    true,
 			Description: "IDP provider URL",
 		},
-		"scopes": schema.ListAttribute{
+		"scopes": schema.SetAttribute{
 			Optional:    true,
 			ElementType: types.StringType,
 			Description: "Scopes",
@@ -434,12 +434,12 @@ var SettingsResourceSchema = schema.Schema{
 			Description: "Identity provider refresh timeout",
 			CustomType:  timetypes.GoDurationType{},
 		},
-		"access_log_fields": schema.ListAttribute{
+		"access_log_fields": schema.SetAttribute{
 			Optional:    true,
 			ElementType: types.StringType,
 			Description: "Access log fields",
 		},
-		"authorize_log_fields": schema.ListAttribute{
+		"authorize_log_fields": schema.SetAttribute{
 			Optional:    true,
 			ElementType: types.StringType,
 			Description: "Authorize log fields",


### PR DESCRIPTION
Updates data model to use `Set` instead of a `List` where order of elements has no significance. 

https://linear.app/pomerium/issue/ENG-1950/use-sets-where-appropriate-for-order-insensitive-fields