### PR TITLE
add provider config validity checks

### DIFF
--- a/internal/provider/bootstrap_service_account.go
+++ b/internal/provider/bootstrap_service_account.go
@@ -19,6 +19,10 @@ func GenerateBootstrapServiceAccountToken(
 		return "", fmt.Errorf("shared_secret is invalid: %w", err)
 	}
 
+	if len(sharedSecret) == 0 {
+		return "", fmt.Errorf("shared_secret is empty")
+	}
+
 	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: sharedSecret},
 		(&jose.SignerOptions{}).WithType("JWT"))
 	if err != nil {

--- a/internal/provider/bootstrap_service_account_test.go
+++ b/internal/provider/bootstrap_service_account_test.go
@@ -33,6 +33,11 @@ func TestGenerateBootstrapServiceAccountToken(t *testing.T) {
 				require.Len(t, parts, 3)
 			},
 		},
+		{
+			name:         "empty secret",
+			sharedSecret: "",
+			expectError:  true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -112,6 +112,10 @@ func (p *PomeriumProvider) Configure(ctx context.Context, req provider.Configure
 	var token string
 	if !data.ServiceAccountToken.IsNull() {
 		token = data.ServiceAccountToken.ValueString()
+		if token == "" {
+			resp.Diagnostics.AddError("service_account_token is empty", "service_account_token is empty")
+			return
+		}
 	} else if !data.SharedSecretB64.IsNull() {
 		token, err = GenerateBootstrapServiceAccountToken(data.SharedSecretB64.ValueString())
 		if err != nil {


### PR DESCRIPTION
if provider is configured with empty secrets, it may error in an unrelated area while performing requests. 
this PR adds an additional checks for the config to be correct. 

