### PR TITLE
convert: handle unknown values

### DIFF
--- a/internal/provider/convert.go
+++ b/internal/provider/convert.go
@@ -76,7 +76,7 @@ func FromStringMap(m map[string]string) types.Map {
 
 // ToStringList converts a types.List to Settings_StringList and handles diagnostics internally
 func ToStringListFromSet(ctx context.Context, dst **pb.Settings_StringList, set types.Set, diagnostics *diag.Diagnostics) {
-	if set.IsNull() {
+	if set.IsNull() || set.IsUnknown() {
 		*dst = nil
 		return
 	}
@@ -90,7 +90,7 @@ func ToStringListFromSet(ctx context.Context, dst **pb.Settings_StringList, set 
 
 // ToStringMap converts a types.Map to map[string]string and handles diagnostics internally
 func ToStringMap(ctx context.Context, dst *map[string]string, m types.Map, diagnostics *diag.Diagnostics) {
-	if m.IsNull() {
+	if m.IsNull() || m.IsUnknown() {
 		*dst = nil
 		return
 	}
@@ -103,25 +103,28 @@ func ToStringMap(ctx context.Context, dst *map[string]string, m types.Map, diagn
 }
 
 func ToStringSliceFromSet(ctx context.Context, dst *[]string, set types.Set, diagnostics *diag.Diagnostics) {
-	*dst = make([]string, 0)
-	if !set.IsNull() {
-		var values []string
-		diagnostics.Append(set.ElementsAs(ctx, &values, false)...)
-		if !diagnostics.HasError() {
-			*dst = values
-		}
+	if set.IsNull() || set.IsUnknown() {
+		*dst = nil
+		return
+	}
+	var values []string
+	diagnostics.Append(set.ElementsAs(ctx, &values, false)...)
+	if !diagnostics.HasError() {
+		*dst = values
 	}
 }
 
 // ToStringSliceFromList converts a types.List to string slice and handles diagnostics internally
 func ToStringSliceFromList(ctx context.Context, dst *[]string, list types.List, diagnostics *diag.Diagnostics) {
-	*dst = make([]string, 0)
-	if !list.IsNull() {
-		var values []string
-		diagnostics.Append(list.ElementsAs(ctx, &values, false)...)
-		if !diagnostics.HasError() {
-			*dst = values
-		}
+	if list.IsNull() || list.IsUnknown() {
+		*dst = nil
+		return
+	}
+
+	var values []string
+	diagnostics.Append(list.ElementsAs(ctx, &values, false)...)
+	if !diagnostics.HasError() {
+		*dst = values
 	}
 }
 

--- a/internal/provider/convert_test.go
+++ b/internal/provider/convert_test.go
@@ -153,6 +153,13 @@ func TestToStringListFromSet(t *testing.T) {
 			},
 		},
 		{
+			name:  "unknown set",
+			input: types.SetUnknown(types.StringType),
+			validate: func(t *testing.T, s *pb.Settings_StringList) {
+				assert.Nil(t, s)
+			},
+		},
+		{
 			name:  "empty list",
 			input: types.SetValueMust(types.StringType, []attr.Value{}),
 			validate: func(t *testing.T, s *pb.Settings_StringList) {
@@ -491,11 +498,16 @@ func TestToStringSliceFromSet(t *testing.T) {
 		{
 			name:     "null set",
 			input:    types.SetNull(types.StringType),
-			expected: []string{},
+			expected: nil,
+		},
+		{
+			name:     "unknown set",
+			input:    types.SetUnknown(types.StringType),
+			expected: nil,
 		},
 		{
 			name:     "empty set",
-			input:    types.SetValueMust(types.StringType, []attr.Value{}),
+			input:    types.SetValueMust(types.StringType, nil),
 			expected: []string{},
 		},
 		{
@@ -595,7 +607,12 @@ func TestToStringSliceFromList(t *testing.T) {
 		{
 			name:     "null list",
 			input:    types.ListNull(types.StringType),
-			expected: []string{},
+			expected: nil,
+		},
+		{
+			name:     "unknown list",
+			input:    types.ListUnknown(types.StringType),
+			expected: nil,
 		},
 		{
 			name:     "empty list",
@@ -633,7 +650,12 @@ func TestToStringMap(t *testing.T) {
 		{
 			name:     "null map",
 			input:    types.MapNull(types.StringType),
-			expected: nil, // Changed from empty map to nil to match implementation
+			expected: nil,
+		},
+		{
+			name:     "unknown map",
+			input:    types.MapUnknown(types.StringType),
+			expected: nil,
 		},
 		{
 			name:     "empty map",
@@ -780,10 +802,10 @@ func TestToRouteStringList(t *testing.T) {
 			0,
 		},
 		{
-			"invalid",
-			types.SetValueMust(types.BoolType, []attr.Value{types.BoolValue(true)}),
+			"unknown",
+			types.SetUnknown(types.StringType),
 			nil,
-			1,
+			0,
 		},
 		{
 			"empty",
@@ -827,10 +849,10 @@ func TestToSettingsStringList(t *testing.T) {
 			0,
 		},
 		{
-			"invalid",
-			types.SetValueMust(types.BoolType, []attr.Value{types.BoolValue(true)}),
+			"unknown",
+			types.SetUnknown(types.StringType),
 			nil,
-			1,
+			0,
 		},
 		{
 			"empty",


### PR DESCRIPTION
we were not handling `unknown` values correctly for some of the types, that could cause a runtime error. 

Fix: https://linear.app/pomerium/issue/ENG-2088/value-conversion-error-occurs-after-upgrading-tp-to-v0011-and-changing

