### PR TITLE
fix missing cluster id on all namespaces

### DIFF
--- a/internal/provider/namespaces_data_source.go
+++ b/internal/provider/namespaces_data_source.go
@@ -50,6 +50,11 @@ func (d *NamespacesDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 							Computed:    true,
 							Description: "ID of the parent namespace.",
 						},
+						"cluster_id": schema.StringAttribute{
+							Computed:    true,
+							Optional:    true,
+							Description: "ID of the cluster (optional).",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
This property was missing from the all namespaces datasource.