### PR TITLE
terraform/policy: update duplicate named policies

### DIFF
--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	client "github.com/pomerium/enterprise-client-go"
 	"github.com/pomerium/enterprise-client-go/pb"
@@ -123,16 +124,46 @@ func (r *PolicyResource) Create(ctx context.Context, req resource.CreateRequest,
 				return
 			}
 
-			createReq := newConnectRequest(&pomerium.CreatePolicyRequest{
-				Policy: apiPolicy,
-			}, apiPolicy)
-			createRes, err := client.CreatePolicy(ctx, createReq)
+			apiPolicy, err := createOrUpdate(
+				func() (*pomerium.Policy, error) {
+					createReq := newConnectRequest(&pomerium.CreatePolicyRequest{
+						Policy: apiPolicy,
+					}, apiPolicy)
+					createRes, err := client.CreatePolicy(ctx, createReq)
+					if err != nil {
+						return nil, err
+					}
+					return createRes.Msg.Policy, nil
+				},
+				func(filter *structpb.Struct) ([]*pomerium.Policy, error) {
+					listReq := newConnectRequest(&pomerium.ListPoliciesRequest{
+						Limit:  new(uint64(1)),
+						Filter: filter,
+					}, apiPolicy)
+					listRes, err := client.ListPolicies(ctx, listReq)
+					if err != nil {
+						return nil, err
+					}
+					return listRes.Msg.Policies, nil
+				},
+				func() (*pomerium.Policy, error) {
+					updateReq := newConnectRequest(&pomerium.UpdatePolicyRequest{
+						Policy: apiPolicy,
+					}, apiPolicy)
+					updateRes, err := client.UpdatePolicy(ctx, updateReq)
+					if err != nil {
+						return nil, err
+					}
+					return updateRes.Msg.Policy, nil
+				},
+				apiPolicy,
+			)
 			if err != nil {
 				resp.Diagnostics.AddError("Error creating policy", err.Error())
 				return
 			}
 
-			plan = NewAPIToModelConverter(&resp.Diagnostics).Policy(createRes.Msg.Policy)
+			plan = NewAPIToModelConverter(&resp.Diagnostics).Policy(apiPolicy)
 		},
 		func(client *client.Client) {
 			pbPolicy := NewModelToEnterpriseConverter(&resp.Diagnostics).Policy(plan)

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -1,0 +1,45 @@
+package provider
+
+import (
+	"fmt"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func createOrUpdate[T proto.Message](
+	create func() (T, error),
+	list func(filter *structpb.Struct) ([]T, error),
+	update func() (T, error),
+	obj T,
+) (T, error) {
+	newObj, err := create()
+	if connect.CodeOf(err) == connect.CodeAlreadyExists {
+		filter := &structpb.Struct{Fields: map[string]*structpb.Value{}}
+		if o, ok := any(obj).(interface{ GetName() string }); ok && o.GetName() != "" {
+			filter.Fields["name"] = structpb.NewStringValue(o.GetName())
+		}
+		if o, ok := any(obj).(interface{ GetNamespaceId() string }); ok && o.GetNamespaceId() != "" {
+			filter.Fields["namespace_id"] = structpb.NewStringValue(o.GetNamespaceId())
+		}
+		objs, err := list(filter)
+		if err != nil {
+			return obj, fmt.Errorf("error listing existing objects: %w", err)
+		} else if len(objs) == 0 {
+			return obj, fmt.Errorf("no existing object found")
+		}
+		obj.ProtoReflect().Set(
+			obj.ProtoReflect().Descriptor().Fields().ByName("id"),
+			objs[0].ProtoReflect().Get(objs[0].ProtoReflect().Descriptor().Fields().ByName("id")),
+		)
+		newObj, err = update()
+		if err != nil {
+			return obj, fmt.Errorf("error updating object: %w", err)
+		}
+	} else if err != nil {
+		return obj, fmt.Errorf("error creating object: %w", err)
+	}
+
+	return newObj, nil
+}


### PR DESCRIPTION
For [ENG-3688](https://linear.app/pomerium/issue/ENG-3688/terraform-zero-terraform-apply-fails-with-policy-with-this-name)

Update policies if a policy already exists with the same name.