### PR TITLE
terraform/config: add missing legacy fields, use exaustruct linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - dogsled
     - errcheck
     - errorlint
+    - exhaustruct
     - gocheckcompilerdirectives
     - goprintffuncname
     - gosec
@@ -33,6 +34,7 @@ linters:
       - linters:
           - bodyclose
           - errcheck
+          - exhaustruct
           - gosec
           - staticcheck
           - unused
@@ -52,6 +54,9 @@ linters:
           - golint
           - revive
         text: should have a package comment
+      - linters:
+          - exhaustruct
+        text: ^((schema|timetypes)[.][a-zA-Z0-9]+|provider.PolicyLanguage|provider.PolicyLanguageType)[ ]is missing
     paths:
       - third_party$
       - builtin$

--- a/internal/provider/bootstrap_service_account.go
+++ b/internal/provider/bootstrap_service_account.go
@@ -24,7 +24,7 @@ func GenerateBootstrapServiceAccountToken(
 	}
 
 	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: sharedSecret},
-		(&jose.SignerOptions{}).WithType("JWT"))
+		(new(jose.SignerOptions)).WithType("JWT"))
 	if err != nil {
 		return "", status.Errorf(codes.Internal, "signing JWT: %s", err.Error())
 	}

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -57,7 +57,10 @@ func NewClient(apiURL, serviceAccountToken, sharedSecretB64 string, tlsConfig *t
 	httpTransport.ForceAttemptHTTP2 = true
 	httpTransport.TLSClientConfig = tlsConfig
 	httpClient := &http.Client{
-		Transport: httpTransport,
+		CheckRedirect: nil,
+		Jar:           nil,
+		Timeout:       0,
+		Transport:     httpTransport,
 	}
 
 	consolidatedClient := sdk.NewClient(

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -83,7 +83,7 @@ type ClusterDataSource struct {
 
 // NewClusterDataSource creates a new cluster data source.
 func NewClusterDataSource() datasource.DataSource {
-	return &ClusterDataSource{}
+	return new(ClusterDataSource)
 }
 
 func (*ClusterDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -27,7 +27,7 @@ type ClusterResource struct {
 
 // NewClusterResource creates a new clusters resource.
 func NewClusterResource() resource.Resource {
-	return &ClusterResource{}
+	return new(ClusterResource)
 }
 
 func (r *ClusterResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {

--- a/internal/provider/clusters_data_source.go
+++ b/internal/provider/clusters_data_source.go
@@ -22,7 +22,7 @@ type ClustersDataSource struct {
 
 // NewClustersDataSource creates a new clusters data source.
 func NewClustersDataSource() datasource.DataSource {
-	return &ClustersDataSource{}
+	return new(ClustersDataSource)
 }
 
 func (*ClustersDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/converters_api_to_model.go
+++ b/internal/provider/converters_api_to_model.go
@@ -164,7 +164,8 @@ func (c *APIToModelConverter) KeyPair(src *pomerium.KeyPair) KeyPairModel {
 }
 
 func (c *APIToModelConverter) Policy(src *pomerium.Policy) PolicyModel {
-	ppl, err := PolicyLanguageType{}.Parse(types.StringPointerValue(src.SourcePpl))
+	var policyLanguageType PolicyLanguageType
+	ppl, err := policyLanguageType.Parse(types.StringPointerValue(src.SourcePpl))
 	if err != nil {
 		c.diagnostics.AddError("error parsing ppl", err.Error())
 	}

--- a/internal/provider/converters_enterprise_to_model.go
+++ b/internal/provider/converters_enterprise_to_model.go
@@ -24,6 +24,18 @@ func NewEnterpriseToModelConverter(diagnostics *diag.Diagnostics) *EnterpriseToM
 	}
 }
 
+func (c *EnterpriseToModelConverter) BlobStorageSettings(src *enterprise.BlobStorageSettings) types.Object {
+	if src == nil {
+		return types.ObjectNull(BlobStorageSettingsObjectType().AttrTypes)
+	}
+	dst, diagnostics := types.ObjectValue(BlobStorageSettingsObjectType().AttrTypes, map[string]attr.Value{
+		"bucket_uri":     types.StringPointerValue(src.BucketUri),
+		"managed_prefix": types.StringNull(),
+	})
+	c.diagnostics.Append(diagnostics...)
+	return dst
+}
+
 func (c *EnterpriseToModelConverter) CircuitBreakerThresholds(src *enterprise.CircuitBreakerThresholds) types.Object {
 	if src == nil {
 		return types.ObjectNull(CircuitBreakerThresholdsObjectType().AttrTypes)
@@ -220,7 +232,8 @@ func (c *EnterpriseToModelConverter) NamespacePermission(src *enterprise.Namespa
 }
 
 func (c *EnterpriseToModelConverter) Policy(src *enterprise.Policy) PolicyModel {
-	ppl, err := PolicyLanguageType{}.Parse(types.StringValue(src.Ppl))
+	var policyLanguageType PolicyLanguageType
+	ppl, err := policyLanguageType.Parse(types.StringValue(src.Ppl))
 	if err != nil {
 		c.diagnostics.AddError("error parsing ppl", err.Error())
 	}
@@ -246,7 +259,7 @@ func (c *EnterpriseToModelConverter) Route(src *enterprise.Route) RouteModel {
 		CircuitBreakerThresholds: c.CircuitBreakerThresholds(src.CircuitBreakerThresholds),
 		DependsOnHosts:           FromStringSliceToSet(src.DependsOn),
 		Description:              types.StringPointerValue(src.Description),
-		EnableGoogleCloudServerlessAuthentication: types.BoolPointerValue(zeroToNil(src.EnableGoogleCloudServerlessAuthentication)),
+		EnableGoogleCloudServerlessAuthentication: types.BoolValue(src.EnableGoogleCloudServerlessAuthentication),
 		From:                              types.StringValue(src.From),
 		HealthChecks:                      toSetOfObjects(src.HealthChecks, HealthCheckObjectType(), c.HealthCheck),
 		HealthyPanicThreshold:             types.Int32PointerValue(src.HealthyPanicThreshold),
@@ -292,6 +305,7 @@ func (c *EnterpriseToModelConverter) Route(src *enterprise.Route) RouteModel {
 		TLSUpstreamAllowRenegotiation:     types.BoolPointerValue(src.TlsUpstreamAllowRenegotiation),
 		TLSUpstreamServerName:             types.StringPointerValue(src.TlsUpstreamServerName),
 		To:                                FromStringSliceToSet(src.To),
+		UpstreamTunnel:                    c.UpstreamTunnel(src.UpstreamTunnel),
 	}
 }
 
@@ -383,46 +397,49 @@ func (c *EnterpriseToModelConverter) ServiceAccount(src *enterprise.PomeriumServ
 
 func (c *EnterpriseToModelConverter) Settings(src *enterprise.Settings) SettingsModel {
 	return SettingsModel{
-		AccessLogFields:               FromStringListToSet(src.AccessLogFields),
-		Address:                       types.StringPointerValue(src.Address),
-		AuthenticateServiceURL:        types.StringPointerValue(src.AuthenticateServiceUrl),
-		AuthorizeLogFields:            FromStringListToSet(src.AuthorizeLogFields),
-		AuthorizeServiceURL:           types.StringPointerValue(src.AuthorizeServiceUrl),
-		Autocert:                      types.BoolPointerValue(src.Autocert),
-		AutocertDir:                   types.StringPointerValue(src.AutocertDir),
-		AutocertMustStaple:            types.BoolPointerValue(src.AutocertMustStaple),
-		AutocertUseStaging:            types.BoolPointerValue(src.AutocertUseStaging),
-		BearerTokenFormat:             c.BearerTokenFormat(src.BearerTokenFormat),
-		CacheServiceURL:               types.StringPointerValue(src.CacheServiceUrl),
-		CertificateAuthority:          types.StringPointerValue(src.CertificateAuthority),
-		CertificateAuthorityFile:      types.StringPointerValue(src.CertificateAuthorityFile),
-		CertificateAuthorityKeyPairID: types.StringPointerValue(src.CertificateAuthorityKeyPairId),
-		CircuitBreakerThresholds:      c.CircuitBreakerThresholds(src.CircuitBreakerThresholds),
-		ClientCA:                      types.StringPointerValue(src.ClientCa),
-		ClientCAFile:                  types.StringPointerValue(src.ClientCaFile),
-		ClientCAKeyPairID:             types.StringPointerValue(src.ClientCaKeyPairId),
-		ClusterID:                     types.StringPointerValue(src.ClusterId),
-		CodecType:                     c.CodecType(src.CodecType),
-		CookieDomain:                  types.StringPointerValue(src.CookieDomain),
-		CookieExpire:                  c.Duration(src.CookieExpire),
-		CookieHTTPOnly:                types.BoolPointerValue(src.CookieHttpOnly),
-		CookieName:                    types.StringPointerValue(src.CookieName),
-		CookieSameSite:                types.StringPointerValue(src.CookieSameSite),
-		CookieSecret:                  types.StringPointerValue(src.CookieSecret),
-		CookieSecure:                  types.BoolPointerValue(src.CookieSecure),
-		DarkmodePrimaryColor:          types.StringPointerValue(src.DarkmodePrimaryColor),
-		DarkmodeSecondaryColor:        types.StringPointerValue(src.DarkmodeSecondaryColor),
-		DatabrokerServiceURL:          types.StringPointerValue(src.DatabrokerServiceUrl),
-		DefaultUpstreamTimeout:        c.Duration(src.DefaultUpstreamTimeout),
-		DNSFailureRefreshRate:         c.Duration(src.DnsFailureRefreshRate),
-		DNSLookupFamily:               types.StringPointerValue(src.DnsLookupFamily),
-		DNSQueryTimeout:               c.Duration(src.DnsQueryTimeout),
-		DNSQueryTries:                 Int64PointerValue(src.DnsQueryTries),
-		DNSRefreshRate:                c.Duration(src.DnsRefreshRate),
-		DNSUDPMaxQueries:              Int64PointerValue(src.DnsUdpMaxQueries),
-		DNSUseTCP:                     types.BoolPointerValue(src.DnsUseTcp),
-		ErrorMessageFirstParagraph:    types.StringPointerValue(src.ErrorMessageFirstParagraph),
-		FaviconURL:                    types.StringPointerValue(src.FaviconUrl),
+		AccessLogFields:                   FromStringListToSet(src.AccessLogFields),
+		Address:                           types.StringPointerValue(src.Address),
+		AuthenticateServiceURL:            types.StringPointerValue(src.AuthenticateServiceUrl),
+		AuthorizeLogFields:                FromStringListToSet(src.AuthorizeLogFields),
+		AuthorizeServiceURL:               types.StringPointerValue(src.AuthorizeServiceUrl),
+		AutoApplyChangesets:               types.BoolPointerValue(src.AutoApplyChangesets),
+		Autocert:                          types.BoolPointerValue(src.Autocert),
+		AutocertDir:                       types.StringPointerValue(src.AutocertDir),
+		AutocertMustStaple:                types.BoolPointerValue(src.AutocertMustStaple),
+		AutocertUseStaging:                types.BoolPointerValue(src.AutocertUseStaging),
+		BearerTokenFormat:                 c.BearerTokenFormat(src.BearerTokenFormat),
+		BlobStorage:                       c.BlobStorageSettings(src.BlobStorage),
+		CacheServiceURL:                   types.StringPointerValue(src.CacheServiceUrl),
+		CertificateAuthority:              types.StringPointerValue(src.CertificateAuthority),
+		CertificateAuthorityFile:          types.StringPointerValue(src.CertificateAuthorityFile),
+		CertificateAuthorityKeyPairID:     types.StringPointerValue(src.CertificateAuthorityKeyPairId),
+		CircuitBreakerThresholds:          c.CircuitBreakerThresholds(src.CircuitBreakerThresholds),
+		ClientCA:                          types.StringPointerValue(src.ClientCa),
+		ClientCAFile:                      types.StringPointerValue(src.ClientCaFile),
+		ClientCAKeyPairID:                 types.StringPointerValue(src.ClientCaKeyPairId),
+		ClusterID:                         types.StringPointerValue(src.ClusterId),
+		CodecType:                         c.CodecType(src.CodecType),
+		CookieDomain:                      types.StringPointerValue(src.CookieDomain),
+		CookieExpire:                      c.Duration(src.CookieExpire),
+		CookieHTTPOnly:                    types.BoolPointerValue(src.CookieHttpOnly),
+		CookieName:                        types.StringPointerValue(src.CookieName),
+		CookieSameSite:                    types.StringPointerValue(src.CookieSameSite),
+		CookieSecret:                      types.StringPointerValue(src.CookieSecret),
+		CookieSecure:                      types.BoolPointerValue(src.CookieSecure),
+		DarkmodePrimaryColor:              types.StringPointerValue(src.DarkmodePrimaryColor),
+		DarkmodeSecondaryColor:            types.StringPointerValue(src.DarkmodeSecondaryColor),
+		DatabrokerServiceURL:              types.StringPointerValue(src.DatabrokerServiceUrl),
+		DatabrokerStorageConnectionString: types.StringNull(), // not supported
+		DefaultUpstreamTimeout:            c.Duration(src.DefaultUpstreamTimeout),
+		DNSFailureRefreshRate:             c.Duration(src.DnsFailureRefreshRate),
+		DNSLookupFamily:                   types.StringPointerValue(src.DnsLookupFamily),
+		DNSQueryTimeout:                   c.Duration(src.DnsQueryTimeout),
+		DNSQueryTries:                     Int64PointerValue(src.DnsQueryTries),
+		DNSRefreshRate:                    c.Duration(src.DnsRefreshRate),
+		DNSUDPMaxQueries:                  Int64PointerValue(src.DnsUdpMaxQueries),
+		DNSUseTCP:                         types.BoolPointerValue(src.DnsUseTcp),
+		ErrorMessageFirstParagraph:        types.StringPointerValue(src.ErrorMessageFirstParagraph),
+		FaviconURL:                        types.StringPointerValue(src.FaviconUrl),
 		GoogleCloudServerlessAuthenticationServiceAccount: types.StringPointerValue(src.GoogleCloudServerlessAuthenticationServiceAccount),
 		GRPCAddress:                     types.StringPointerValue(src.GrpcAddress),
 		GRPCInsecure:                    types.BoolPointerValue(src.GrpcInsecure),
@@ -458,6 +475,7 @@ func (c *EnterpriseToModelConverter) Settings(src *enterprise.Settings) Settings
 		MCPAllowedAsMetadataDomains:     FromStringList(src.McpAllowedAsMetadataDomains),
 		MCPAllowedClientIDDomains:       FromStringList(src.McpAllowedClientIdDomains),
 		MetricsAddress:                  types.StringPointerValue(src.MetricsAddress),
+		NamespaceID:                     types.StringNull(), // not supported
 		OtelAttributeValueLengthLimit:   Int64PointerValue(src.OtelAttributeValueLengthLimit),
 		OtelBspMaxExportBatchSize:       Int64PointerValue(src.OtelBspMaxExportBatchSize),
 		OtelBspScheduleDelay:            c.Duration(src.OtelBspScheduleDelay),
@@ -479,6 +497,7 @@ func (c *EnterpriseToModelConverter) Settings(src *enterprise.Settings) Settings
 		RequestParams:                   FromStringMap(src.RequestParams),
 		Scopes:                          FromStringSliceToSet(src.Scopes),
 		SecondaryColor:                  types.StringPointerValue(src.SecondaryColor),
+		SessionRecordingEnabled:         types.BoolNull(), // not supported
 		SetResponseHeaders:              FromStringMap(src.SetResponseHeaders),
 		SkipXFFAppend:                   types.BoolPointerValue(src.SkipXffAppend),
 		SSHAddress:                      types.StringPointerValue(src.SshAddress),
@@ -490,4 +509,13 @@ func (c *EnterpriseToModelConverter) Settings(src *enterprise.Settings) Settings
 		TimeoutRead:                     c.Duration(src.TimeoutRead),
 		TimeoutWrite:                    c.Duration(src.TimeoutWrite),
 	}
+}
+
+func (c *EnterpriseToModelConverter) UpstreamTunnel(src *enterprise.UpstreamTunnel) types.Object {
+	if src == nil {
+		return types.ObjectNull(UpstreamTunnelObjectType().AttrTypes)
+	}
+	return types.ObjectValueMust(UpstreamTunnelObjectType().AttrTypes, map[string]attr.Value{
+		"ssh_policy": types.StringPointerValue(src.SshPolicyId),
+	})
 }

--- a/internal/provider/converters_enterprise_to_model_test.go
+++ b/internal/provider/converters_enterprise_to_model_test.go
@@ -2,6 +2,7 @@ package provider_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -9,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/enterprise-client-go/pb"
 	"github.com/pomerium/enterprise-terraform-provider/internal/provider"
@@ -123,5 +125,26 @@ func TestEnterpriseToModelConverter(t *testing.T) {
 				assert.Empty(t, cmp.Diff(expect, actual))
 			})
 		})
+	})
+	t.Run("ServiceAccount", func(t *testing.T) {
+		t.Parallel()
+		var diagnostics diag.Diagnostics
+		expect := provider.ServiceAccountModel{
+			Description: types.StringValue("DESCRIPTION"),
+			ExpiresAt:   types.StringValue("2026-01-01T16:00:00Z"),
+			ID:          types.StringValue("ID"),
+			Name:        types.StringValue("NAME"),
+			NamespaceID: types.StringValue("NAMESPACE_ID"),
+			UserID:      types.StringValue("NAME@NAMESPACE_ID.pomerium"),
+		}
+		actual := provider.NewEnterpriseToModelConverter(&diagnostics).ServiceAccount(&pb.PomeriumServiceAccount{
+			Description: new("DESCRIPTION"),
+			ExpiresAt:   timestamppb.New(time.Date(2026, 1, 1, 16, 0, 0, 0, time.UTC)),
+			Id:          "ID",
+			NamespaceId: new("NAMESPACE_ID"),
+			UserId:      "NAME@NAMESPACE_ID.pomerium",
+		})
+		assert.Empty(t, diagnostics)
+		assert.Empty(t, cmp.Diff(expect, actual))
 	})
 }

--- a/internal/provider/converters_model_to_api.go
+++ b/internal/provider/converters_model_to_api.go
@@ -110,13 +110,24 @@ func (c *ModelToAPIConverter) HealthCheck(src types.Object) *pomerium.HealthChec
 	healthyThreshold := attrs["healthy_threshold"].(types.Int64)
 
 	dst := &pomerium.HealthCheck{
-		Timeout:               c.Duration(path.Root("timeout"), timeout),
-		Interval:              c.Duration(path.Root("interval"), interval),
-		InitialJitter:         c.Duration(path.Root("initial_jitter"), initialJitter),
-		IntervalJitter:        c.Duration(path.Root("interval_jitter"), intervalJitter),
-		IntervalJitterPercent: uint32(intervalJitterPercent.ValueInt64()),
-		UnhealthyThreshold:    c.WrappedUint32(unhealthyThreshold),
-		HealthyThreshold:      c.WrappedUint32(healthyThreshold),
+		AltPort:                      nil,   // not supported
+		AlwaysLogHealthCheckFailures: false, // not supported
+		AlwaysLogHealthCheckSuccess:  false, // not supported
+		HealthChecker:                nil,   // set below
+		HealthyEdgeInterval:          nil,   // not supported
+		HealthyThreshold:             c.WrappedUint32(healthyThreshold),
+		InitialJitter:                c.Duration(path.Root("initial_jitter"), initialJitter),
+		Interval:                     c.Duration(path.Root("interval"), interval),
+		IntervalJitter:               c.Duration(path.Root("interval_jitter"), intervalJitter),
+		IntervalJitterPercent:        uint32(intervalJitterPercent.ValueInt64()),
+		NoTrafficHealthyInterval:     nil, // not supported
+		NoTrafficInterval:            nil, // not supported
+		ReuseConnection:              nil, // not supported
+		Timeout:                      c.Duration(path.Root("timeout"), timeout),
+		TransportSocketMatchCriteria: nil, // not supported
+		UnhealthyEdgeInterval:        nil, // not supported
+		UnhealthyInterval:            nil, // not supported
+		UnhealthyThreshold:           c.WrappedUint32(unhealthyThreshold),
 	}
 
 	httpHc := attrs["http_health_check"].(types.Object)
@@ -125,7 +136,17 @@ func (c *ModelToAPIConverter) HealthCheck(src types.Object) *pomerium.HealthChec
 
 	if !httpHc.IsNull() {
 		httpAttrs := httpHc.Attributes()
-		httpHealthCheck := &pomerium.HealthCheck_HttpHealthCheck{}
+		httpHealthCheck := &pomerium.HealthCheck_HttpHealthCheck{
+			CodecClientType:        0,   // set below
+			ExpectedStatuses:       nil, // set below
+			Host:                   "",  // set below
+			Path:                   "",  // set below
+			Receive:                nil, // not supported
+			RequestHeadersToRemove: nil, // not supported
+			ResponseBufferSize:     nil, // not supported
+			RetriableStatuses:      nil, // set below
+			Send:                   nil, // not supported
+		}
 
 		host := httpAttrs["host"].(types.String)
 		httpPath := httpAttrs["path"].(types.String)
@@ -164,7 +185,10 @@ func (c *ModelToAPIConverter) HealthCheck(src types.Object) *pomerium.HealthChec
 		}
 	} else if !tcpHc.IsNull() {
 		tcpAttrs := tcpHc.Attributes()
-		tcpHealthCheck := &pomerium.HealthCheck_TcpHealthCheck{}
+		tcpHealthCheck := &pomerium.HealthCheck_TcpHealthCheck{
+			Receive: nil, // set below
+			Send:    nil, // set below
+		}
 
 		send := tcpAttrs["send"].(types.Object)
 		receive := tcpAttrs["receive"].(types.Set)
@@ -185,7 +209,10 @@ func (c *ModelToAPIConverter) HealthCheck(src types.Object) *pomerium.HealthChec
 		}
 	} else if !grpcHc.IsNull() {
 		grpcAttrs := grpcHc.Attributes()
-		grpcHealthCheck := &pomerium.HealthCheck_GrpcHealthCheck{}
+		grpcHealthCheck := &pomerium.HealthCheck_GrpcHealthCheck{
+			Authority:   "", // set below
+			ServiceName: "", // set below
+		}
 
 		serviceName := grpcAttrs["service_name"].(types.String)
 		authority := grpcAttrs["authority"].(types.String)
@@ -359,62 +386,89 @@ func (c *ModelToAPIConverter) Policy(src PolicyModel) *pomerium.Policy {
 
 func (c *ModelToAPIConverter) Route(src RouteModel) *pomerium.Route {
 	return &pomerium.Route{
-		AllowSpdy:                src.AllowSPDY.ValueBool(),
-		AllowWebsockets:          src.AllowWebsockets.ValueBool(),
-		AssignedPolicies:         c.EntityInfosFromIDs(c.StringSliceFromSet(path.Root("policies"), src.Policies)),
-		BearerTokenFormat:        c.BearerTokenFormat(path.Root("bearer_token_format"), src.BearerTokenFormat),
-		CircuitBreakerThresholds: c.CircuitBreakerThresholds(src.CircuitBreakerThresholds),
-		DependsOn:                c.StringSliceFromSet(path.Root("depends_on"), src.DependsOnHosts),
-		Description:              src.Description.ValueStringPointer(),
+		AllowAnyAuthenticatedUser:        false, // not supported
+		AllowedDomains:                   nil,   // not supported
+		AllowedIdpClaims:                 nil,   // not supported
+		AllowedUsers:                     nil,   // not supported
+		AllowPublicUnauthenticatedAccess: false, // not supported
+		AllowSpdy:                        src.AllowSPDY.ValueBool(),
+		AllowWebsockets:                  src.AllowWebsockets.ValueBool(),
+		AssignedPolicies:                 c.EntityInfosFromIDs(c.StringSliceFromSet(path.Root("policies"), src.Policies)),
+		BearerTokenFormat:                c.BearerTokenFormat(path.Root("bearer_token_format"), src.BearerTokenFormat),
+		CircuitBreakerThresholds:         c.CircuitBreakerThresholds(src.CircuitBreakerThresholds),
+		CorsAllowPreflight:               false, // not supported
+		CreatedAt:                        nil,   // computed
+		DependsOn:                        c.StringSliceFromSet(path.Root("depends_on"), src.DependsOnHosts),
+		Description:                      src.Description.ValueStringPointer(),
 		EnableGoogleCloudServerlessAuthentication: src.EnableGoogleCloudServerlessAuthentication.ValueBool(),
-		From:                              src.From.ValueString(),
-		HealthChecks:                      fromSetOfObjects(src.HealthChecks, HealthCheckObjectType(), c.HealthCheck),
-		HealthyPanicThreshold:             src.HealthyPanicThreshold.ValueInt32Pointer(),
-		HostPathRegexRewritePattern:       src.HostPathRegexRewritePattern.ValueStringPointer(),
-		HostPathRegexRewriteSubstitution:  src.HostPathRegexRewriteSubstitution.ValueStringPointer(),
-		HostRewrite:                       src.HostRewrite.ValueStringPointer(),
-		HostRewriteHeader:                 src.HostRewriteHeader.ValueStringPointer(),
-		Id:                                c.NullableString(src.ID),
-		IdleTimeout:                       c.Duration(path.Root("idle_timeout"), src.IdleTimeout),
-		IdpAccessTokenAllowedAudiences:    c.RouteStringList(path.Root("idp_access_token_allowed_audiences"), src.IDPAccessTokenAllowedAudiences),
-		IdpClientId:                       src.IDPClientID.ValueStringPointer(),
-		IdpClientSecret:                   src.IDPClientSecret.ValueStringPointer(),
-		JwtGroupsFilter:                   c.JWTGroupsFilter(src.JWTGroupsFilter),
-		JwtGroupsFilterInferFromPpl:       c.JWTGroupsFilterInferFromPpl(src.JWTGroupsFilter),
-		JwtIssuerFormat:                   c.IssuerFormat(path.Root("jwt_issuer_format"), src.JWTIssuerFormat),
-		KubernetesServiceAccountToken:     src.KubernetesServiceAccountToken.ValueString(),
-		KubernetesServiceAccountTokenFile: src.KubernetesServiceAccountTokenFile.ValueString(),
-		LoadBalancingPolicy:               c.LoadBalancingPolicy(path.Root("load_balancing_policy"), src.LoadBalancingPolicy),
-		LogoUrl:                           src.LogoURL.ValueStringPointer(),
-		Mcp:                               c.RouteMCP(path.Root("mcp"), src.MCP),
-		Name:                              c.NullableString(src.Name),
-		NamespaceId:                       c.NullableString(src.NamespaceID),
-		OriginatorId:                      new(OriginatorID),
-		PassIdentityHeaders:               src.PassIdentityHeaders.ValueBoolPointer(),
-		Path:                              src.Path.ValueString(),
-		PolicyIds:                         c.StringSliceFromSet(path.Root("policies"), src.Policies),
-		Prefix:                            src.Prefix.ValueString(),
-		PrefixRewrite:                     src.PrefixRewrite.ValueString(),
-		PreserveHostHeader:                src.PreserveHostHeader.ValueBool(),
-		Regex:                             src.Regex.ValueString(),
-		RegexPriorityOrder:                src.RegexPriorityOrder.ValueInt64Pointer(),
-		RegexRewritePattern:               src.RegexRewritePattern.ValueString(),
-		RegexRewriteSubstitution:          src.RegexRewriteSubstitution.ValueString(),
-		RemoveRequestHeaders:              c.StringSliceFromSet(path.Root("remove_request_headers"), src.RemoveRequestHeaders),
-		RewriteResponseHeaders:            fromSetOfObjects(src.RewriteResponseHeaders, RewriteHeaderObjectType(), c.RouteRewriteHeader),
-		SetRequestHeaders:                 c.StringMap(path.Root("set_request_headers"), src.SetRequestHeaders),
-		SetResponseHeaders:                c.StringMap(path.Root("set_response_headers"), src.SetResponseHeaders),
-		ShowErrorDetails:                  src.ShowErrorDetails.ValueBool(),
-		StatName:                          c.NullableString(src.StatName),
-		Timeout:                           c.Duration(path.Root("timeout"), src.Timeout),
-		TlsClientKeyPairId:                src.TLSClientKeyPairID.ValueStringPointer(),
-		TlsCustomCaKeyPairId:              src.TLSCustomCAKeyPairID.ValueStringPointer(),
-		TlsDownstreamServerName:           src.TLSDownstreamServerName.ValueString(),
-		TlsSkipVerify:                     src.TLSSkipVerify.ValueBool(),
-		TlsUpstreamAllowRenegotiation:     src.TLSUpstreamAllowRenegotiation.ValueBool(),
-		TlsUpstreamServerName:             src.TLSUpstreamServerName.ValueString(),
-		To:                                c.StringSliceFromSet(path.Root("to"), src.To),
-		UpstreamTunnel:                    c.UpstreamTunnel(path.Root("upstream_tunnel"), src.UpstreamTunnel),
+		EnforcedPolicies:                       nil, // computed
+		From:                                   src.From.ValueString(),
+		HealthChecks:                           fromSetOfObjects(src.HealthChecks, HealthCheckObjectType(), c.HealthCheck),
+		HealthyPanicThreshold:                  src.HealthyPanicThreshold.ValueInt32Pointer(),
+		HostPathRegexRewritePattern:            src.HostPathRegexRewritePattern.ValueStringPointer(),
+		HostPathRegexRewriteSubstitution:       src.HostPathRegexRewriteSubstitution.ValueStringPointer(),
+		HostRewrite:                            src.HostRewrite.ValueStringPointer(),
+		HostRewriteHeader:                      src.HostRewriteHeader.ValueStringPointer(),
+		Id:                                     c.NullableString(src.ID),
+		IdleTimeout:                            c.Duration(path.Root("idle_timeout"), src.IdleTimeout),
+		IdpAccessTokenAllowedAudiences:         c.RouteStringList(path.Root("idp_access_token_allowed_audiences"), src.IDPAccessTokenAllowedAudiences),
+		IdpClientId:                            src.IDPClientID.ValueStringPointer(),
+		IdpClientSecret:                        src.IDPClientSecret.ValueStringPointer(),
+		JwtGroupsFilter:                        c.JWTGroupsFilter(src.JWTGroupsFilter),
+		JwtGroupsFilterInferFromPpl:            c.JWTGroupsFilterInferFromPpl(src.JWTGroupsFilter),
+		JwtIssuerFormat:                        c.IssuerFormat(path.Root("jwt_issuer_format"), src.JWTIssuerFormat),
+		KubernetesServiceAccountToken:          src.KubernetesServiceAccountToken.ValueString(),
+		KubernetesServiceAccountTokenFile:      src.KubernetesServiceAccountTokenFile.ValueString(),
+		KubernetesServiceAccountTokenKeyPairId: nil, // not supported
+		LoadBalancingPolicy:                    c.LoadBalancingPolicy(path.Root("load_balancing_policy"), src.LoadBalancingPolicy),
+		LoadBalancingWeights:                   nil, // not supported
+		LogoUrl:                                src.LogoURL.ValueStringPointer(),
+		Mcp:                                    c.RouteMCP(path.Root("mcp"), src.MCP),
+		ModifiedAt:                             nil, // computed
+		Name:                                   c.NullableString(src.Name),
+		NamespaceId:                            c.NullableString(src.NamespaceID),
+		NamespaceName:                          nil, // computed
+		OriginatorId:                           new(OriginatorID),
+		OutlierDetection:                       nil, // not supported
+		PassIdentityHeaders:                    src.PassIdentityHeaders.ValueBoolPointer(),
+		Path:                                   src.Path.ValueString(),
+		Policies:                               nil, // not supported (uses PolicyIds)
+		PolicyIds:                              c.StringSliceFromSet(path.Root("policies"), src.Policies),
+		PplPolicies:                            nil, // not supported (uses PolicyIds)
+		Prefix:                                 src.Prefix.ValueString(),
+		PrefixRewrite:                          src.PrefixRewrite.ValueString(),
+		PreserveHostHeader:                     src.PreserveHostHeader.ValueBool(),
+		Redirect:                               nil, // not supported
+		Regex:                                  src.Regex.ValueString(),
+		RegexPriorityOrder:                     src.RegexPriorityOrder.ValueInt64Pointer(),
+		RegexRewritePattern:                    src.RegexRewritePattern.ValueString(),
+		RegexRewriteSubstitution:               src.RegexRewriteSubstitution.ValueString(),
+		RemoveRequestHeaders:                   c.StringSliceFromSet(path.Root("remove_request_headers"), src.RemoveRequestHeaders),
+		Response:                               nil, // not supported
+		RewriteResponseHeaders:                 fromSetOfObjects(src.RewriteResponseHeaders, RewriteHeaderObjectType(), c.RouteRewriteHeader),
+		SetRequestHeaders:                      c.StringMap(path.Root("set_request_headers"), src.SetRequestHeaders),
+		SetResponseHeaders:                     c.StringMap(path.Root("set_response_headers"), src.SetResponseHeaders),
+		ShowErrorDetails:                       src.ShowErrorDetails.ValueBool(),
+		StatName:                               c.NullableString(src.StatName),
+		Timeout:                                c.Duration(path.Root("timeout"), src.Timeout),
+		TlsClientCert:                          "", // not supported
+		TlsClientCertFile:                      "", // not supported
+		TlsClientKey:                           "", // not supported
+		TlsClientKeyFile:                       "", // not supported
+		TlsClientKeyPairId:                     src.TLSClientKeyPairID.ValueStringPointer(),
+		TlsCustomCa:                            "", // not supported
+		TlsCustomCaFile:                        "", // not supported
+		TlsCustomCaKeyPairId:                   src.TLSCustomCAKeyPairID.ValueStringPointer(),
+		TlsDownstreamClientCa:                  "",  // not supported
+		TlsDownstreamClientCaFile:              "",  // not supported
+		TlsDownstreamClientCaKeyPairId:         nil, // not supported
+		TlsDownstreamServerName:                src.TLSDownstreamServerName.ValueString(),
+		TlsServerName:                          "", // not supported
+		TlsSkipVerify:                          src.TLSSkipVerify.ValueBool(),
+		TlsUpstreamAllowRenegotiation:          src.TLSUpstreamAllowRenegotiation.ValueBool(),
+		TlsUpstreamServerName:                  src.TLSUpstreamServerName.ValueString(),
+		To:                                     c.StringSliceFromSet(path.Root("to"), src.To),
+		UpstreamTunnel:                         c.UpstreamTunnel(path.Root("upstream_tunnel"), src.UpstreamTunnel),
 	}
 }
 
@@ -489,8 +543,9 @@ func (c *ModelToAPIConverter) RouteRewriteHeader(src types.Object) *pomerium.Rou
 
 	prefixAttr := src.Attributes()["prefix"].(types.String)
 	dst := &pomerium.RouteRewriteHeader{
-		Header: src.Attributes()["header"].(types.String).ValueString(),
-		Value:  src.Attributes()["value"].(types.String).ValueString(),
+		Header:  src.Attributes()["header"].(types.String).ValueString(),
+		Matcher: nil, // set below
+		Value:   src.Attributes()["value"].(types.String).ValueString(),
 	}
 	if !prefixAttr.IsNull() && prefixAttr.ValueString() != "" {
 		dst.Matcher = &pomerium.RouteRewriteHeader_Prefix{Prefix: prefixAttr.ValueString()}

--- a/internal/provider/converters_model_to_enterprise.go
+++ b/internal/provider/converters_model_to_enterprise.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -22,6 +23,18 @@ func NewModelToEnterpriseConverter(diagnostics *diag.Diagnostics) *ModelToEnterp
 	return &ModelToEnterpriseConverter{
 		baseModelConverter: baseModelConverter{diagnostics: diagnostics},
 		diagnostics:        diagnostics,
+	}
+}
+
+func (c *ModelToEnterpriseConverter) BlobStorage(src types.Object) *enterprise.BlobStorageSettings {
+	if src.IsNull() || src.IsUnknown() {
+		return nil
+	}
+
+	attrs := src.Attributes()
+	bucketURI, _ := attrs["bucket_uri"].(types.String)
+	return &enterprise.BlobStorageSettings{
+		BucketUri: c.NullableString(bucketURI),
 	}
 }
 
@@ -80,9 +93,12 @@ func (c *ModelToEnterpriseConverter) ExternalDataSource(src ExternalDataSourceMo
 		AllowInsecureTls: src.AllowInsecureTLS.ValueBoolPointer(),
 		ClientTlsKeyId:   src.ClientTLSKeyID.ValueStringPointer(),
 		ClusterId:        src.ClusterID.ValueStringPointer(),
+		CreatedAt:        nil, // computed
+		DeletedAt:        nil, // computed
 		ForeignKey:       src.ForeignKey.ValueString(),
 		Headers:          c.StringMap(path.Root("headers"), src.Headers),
 		Id:               src.ID.ValueString(),
+		ModifiedAt:       nil, // computed
 		OriginatorId:     OriginatorID,
 		PollingMaxDelay:  c.Duration(path.Root("polling_max_delay"), src.PollingMaxDelay),
 		PollingMinDelay:  c.Duration(path.Root("polling_min_delay"), src.PollingMinDelay),
@@ -108,13 +124,14 @@ func (c *ModelToEnterpriseConverter) HealthCheck(src types.Object) *enterprise.H
 	healthyThreshold := attrs["healthy_threshold"].(types.Int64)
 
 	dst := &enterprise.HealthCheck{
-		Timeout:               c.Duration(path.Root("timeout"), timeout),
-		Interval:              c.Duration(path.Root("interval"), interval),
+		HealthChecker:         nil, // set below
+		HealthyThreshold:      uint32(healthyThreshold.ValueInt64()),
 		InitialJitter:         c.Duration(path.Root("initial_jitter"), initialJitter),
+		Interval:              c.Duration(path.Root("interval"), interval),
 		IntervalJitter:        c.Duration(path.Root("interval_jitter"), intervalJitter),
 		IntervalJitterPercent: uint32(intervalJitterPercent.ValueInt64()),
+		Timeout:               c.Duration(path.Root("timeout"), timeout),
 		UnhealthyThreshold:    uint32(unhealthyThreshold.ValueInt64()),
-		HealthyThreshold:      uint32(healthyThreshold.ValueInt64()),
 	}
 
 	httpHc := attrs["http_health_check"].(types.Object)
@@ -123,7 +140,13 @@ func (c *ModelToEnterpriseConverter) HealthCheck(src types.Object) *enterprise.H
 
 	if !httpHc.IsNull() {
 		httpAttrs := httpHc.Attributes()
-		httpHealthCheck := &enterprise.HealthCheck_HttpHealthCheck{}
+		httpHealthCheck := &enterprise.HealthCheck_HttpHealthCheck{
+			CodecClientType:   0,   // set below
+			ExpectedStatuses:  nil, // set below
+			Host:              "",  // set below
+			Path:              "",  // set below
+			RetriableStatuses: nil, // set below
+		}
 
 		host := httpAttrs["host"].(types.String)
 		httpPath := httpAttrs["path"].(types.String)
@@ -162,7 +185,10 @@ func (c *ModelToEnterpriseConverter) HealthCheck(src types.Object) *enterprise.H
 		}
 	} else if !tcpHc.IsNull() {
 		tcpAttrs := tcpHc.Attributes()
-		tcpHealthCheck := &enterprise.HealthCheck_TcpHealthCheck{}
+		tcpHealthCheck := &enterprise.HealthCheck_TcpHealthCheck{
+			Receive: nil, // set below
+			Send:    nil, // set below
+		}
 
 		send := tcpAttrs["send"].(types.Object)
 		receive := tcpAttrs["receive"].(types.Set)
@@ -183,7 +209,10 @@ func (c *ModelToEnterpriseConverter) HealthCheck(src types.Object) *enterprise.H
 		}
 	} else if !grpcHc.IsNull() {
 		grpcAttrs := grpcHc.Attributes()
-		grpcHealthCheck := &enterprise.HealthCheck_GrpcHealthCheck{}
+		grpcHealthCheck := &enterprise.HealthCheck_GrpcHealthCheck{
+			Authority:   "", // set below
+			ServiceName: "", // set below
+		}
 
 		serviceName := grpcAttrs["service_name"].(types.String)
 		authority := grpcAttrs["authority"].(types.String)
@@ -322,55 +351,66 @@ func (c *ModelToEnterpriseConverter) Route(src RouteModel) *enterprise.Route {
 		AllowWebsockets:          src.AllowWebsockets.ValueBoolPointer(),
 		BearerTokenFormat:        c.BearerTokenFormat(path.Root("bearer_token_format"), src.BearerTokenFormat),
 		CircuitBreakerThresholds: c.CircuitBreakerThresholds(src.CircuitBreakerThresholds),
+		CreatedAt:                nil, // computed
+		DeletedAt:                nil, // computed
 		DependsOn:                c.StringSliceFromSet(path.Root("depends_on"), src.DependsOnHosts),
 		Description:              src.Description.ValueStringPointer(),
 		EnableGoogleCloudServerlessAuthentication: src.EnableGoogleCloudServerlessAuthentication.ValueBool(),
-		From:                              src.From.ValueString(),
-		HealthChecks:                      fromSetOfObjects(src.HealthChecks, HealthCheckObjectType(), c.HealthCheck),
-		HealthyPanicThreshold:             src.HealthyPanicThreshold.ValueInt32Pointer(),
-		HostPathRegexRewritePattern:       src.HostPathRegexRewritePattern.ValueStringPointer(),
-		HostPathRegexRewriteSubstitution:  src.HostPathRegexRewriteSubstitution.ValueStringPointer(),
-		HostRewrite:                       src.HostRewrite.ValueStringPointer(),
-		HostRewriteHeader:                 src.HostRewriteHeader.ValueStringPointer(),
-		Id:                                src.ID.ValueString(),
-		IdleTimeout:                       c.Duration(path.Root("idle_timeout"), src.IdleTimeout),
-		IdpAccessTokenAllowedAudiences:    c.RouteStringList(path.Root("idp_access_token_allowed_audiences"), src.IDPAccessTokenAllowedAudiences),
-		IdpClientId:                       src.IDPClientID.ValueStringPointer(),
-		IdpClientSecret:                   src.IDPClientSecret.ValueStringPointer(),
-		JwtGroupsFilter:                   c.JWTGroupsFilter(src.JWTGroupsFilter),
-		JwtIssuerFormat:                   c.IssuerFormat(path.Root("jwt_issuer_format"), src.JWTIssuerFormat),
-		KubernetesServiceAccountToken:     src.KubernetesServiceAccountToken.ValueStringPointer(),
-		KubernetesServiceAccountTokenFile: src.KubernetesServiceAccountTokenFile.ValueStringPointer(),
-		LoadBalancingPolicy:               c.LoadBalancingPolicy(path.Root("load_balancing_policy"), src.LoadBalancingPolicy),
-		LogoUrl:                           src.LogoURL.ValueStringPointer(),
-		Mcp:                               c.RouteMCP(path.Root("mcp"), src.MCP),
-		Name:                              src.Name.ValueString(),
-		NamespaceId:                       src.NamespaceID.ValueString(),
-		OriginatorId:                      OriginatorID,
-		PassIdentityHeaders:               src.PassIdentityHeaders.ValueBoolPointer(),
-		Path:                              src.Path.ValueStringPointer(),
-		PolicyIds:                         c.StringSliceFromSet(path.Root("policies"), src.Policies),
-		Prefix:                            src.Prefix.ValueStringPointer(),
-		PrefixRewrite:                     src.PrefixRewrite.ValueStringPointer(),
-		PreserveHostHeader:                src.PreserveHostHeader.ValueBoolPointer(),
-		Regex:                             src.Regex.ValueStringPointer(),
-		RegexPriorityOrder:                src.RegexPriorityOrder.ValueInt64Pointer(),
-		RegexRewritePattern:               src.RegexRewritePattern.ValueStringPointer(),
-		RegexRewriteSubstitution:          src.RegexRewriteSubstitution.ValueStringPointer(),
-		RemoveRequestHeaders:              c.StringSliceFromSet(path.Root("remove_request_headers"), src.RemoveRequestHeaders),
-		RewriteResponseHeaders:            fromSetOfObjects(src.RewriteResponseHeaders, RewriteHeaderObjectType(), c.RouteRewriteHeader),
-		SetRequestHeaders:                 c.StringMap(path.Root("set_request_headers"), src.SetRequestHeaders),
-		SetResponseHeaders:                c.StringMap(path.Root("set_response_headers"), src.SetResponseHeaders),
-		ShowErrorDetails:                  src.ShowErrorDetails.ValueBool(),
-		StatName:                          src.StatName.ValueString(),
-		Timeout:                           c.Duration(path.Root("timeout"), src.Timeout),
-		TlsClientKeyPairId:                src.TLSClientKeyPairID.ValueStringPointer(),
-		TlsCustomCaKeyPairId:              src.TLSCustomCAKeyPairID.ValueStringPointer(),
-		TlsDownstreamServerName:           src.TLSDownstreamServerName.ValueStringPointer(),
-		TlsSkipVerify:                     src.TLSSkipVerify.ValueBoolPointer(),
-		TlsUpstreamAllowRenegotiation:     src.TLSUpstreamAllowRenegotiation.ValueBoolPointer(),
-		TlsUpstreamServerName:             src.TLSUpstreamServerName.ValueStringPointer(),
-		To:                                c.StringSliceFromSet(path.Root("to"), src.To),
+		EnforcedPolicyIds:                         nil, // computed
+		EnforcedPolicyNames:                       nil, // computed
+		From:                                      src.From.ValueString(),
+		HealthChecks:                              fromSetOfObjects(src.HealthChecks, HealthCheckObjectType(), c.HealthCheck),
+		HealthyPanicThreshold:                     src.HealthyPanicThreshold.ValueInt32Pointer(),
+		HostPathRegexRewritePattern:               src.HostPathRegexRewritePattern.ValueStringPointer(),
+		HostPathRegexRewriteSubstitution:          src.HostPathRegexRewriteSubstitution.ValueStringPointer(),
+		HostRewrite:                               src.HostRewrite.ValueStringPointer(),
+		HostRewriteHeader:                         src.HostRewriteHeader.ValueStringPointer(),
+		Id:                                        src.ID.ValueString(),
+		IdleTimeout:                               c.Duration(path.Root("idle_timeout"), src.IdleTimeout),
+		IdpAccessTokenAllowedAudiences:            c.RouteStringList(path.Root("idp_access_token_allowed_audiences"), src.IDPAccessTokenAllowedAudiences),
+		IdpClientId:                               src.IDPClientID.ValueStringPointer(),
+		IdpClientSecret:                           src.IDPClientSecret.ValueStringPointer(),
+		JwtGroupsFilter:                           c.JWTGroupsFilter(src.JWTGroupsFilter),
+		JwtIssuerFormat:                           c.IssuerFormat(path.Root("jwt_issuer_format"), src.JWTIssuerFormat),
+		KubernetesServiceAccountToken:             src.KubernetesServiceAccountToken.ValueStringPointer(),
+		KubernetesServiceAccountTokenFile:         src.KubernetesServiceAccountTokenFile.ValueStringPointer(),
+		LoadBalancingPolicy:                       c.LoadBalancingPolicy(path.Root("load_balancing_policy"), src.LoadBalancingPolicy),
+		LogoUrl:                                   src.LogoURL.ValueStringPointer(),
+		Mcp:                                       c.RouteMCP(path.Root("mcp"), src.MCP),
+		ModifiedAt:                                nil, // computed
+		Name:                                      src.Name.ValueString(),
+		NamespaceId:                               src.NamespaceID.ValueString(),
+		NamespaceName:                             "", // computed
+		OriginatorId:                              OriginatorID,
+		PassIdentityHeaders:                       src.PassIdentityHeaders.ValueBoolPointer(),
+		Path:                                      src.Path.ValueStringPointer(),
+		PolicyIds:                                 c.StringSliceFromSet(path.Root("policies"), src.Policies),
+		PolicyNames:                               nil, // computed
+		Prefix:                                    src.Prefix.ValueStringPointer(),
+		PrefixRewrite:                             src.PrefixRewrite.ValueStringPointer(),
+		PreserveHostHeader:                        src.PreserveHostHeader.ValueBoolPointer(),
+		Redirect:                                  nil, // not supported
+		Regex:                                     src.Regex.ValueStringPointer(),
+		RegexPriorityOrder:                        src.RegexPriorityOrder.ValueInt64Pointer(),
+		RegexRewritePattern:                       src.RegexRewritePattern.ValueStringPointer(),
+		RegexRewriteSubstitution:                  src.RegexRewriteSubstitution.ValueStringPointer(),
+		RemoveRequestHeaders:                      c.StringSliceFromSet(path.Root("remove_request_headers"), src.RemoveRequestHeaders),
+		Response:                                  nil, // not supported
+		RewriteResponseHeaders:                    fromSetOfObjects(src.RewriteResponseHeaders, RewriteHeaderObjectType(), c.RouteRewriteHeader),
+		SetRequestHeaders:                         c.StringMap(path.Root("set_request_headers"), src.SetRequestHeaders),
+		SetResponseHeaders:                        c.StringMap(path.Root("set_response_headers"), src.SetResponseHeaders),
+		ShowErrorDetails:                          src.ShowErrorDetails.ValueBool(),
+		StatName:                                  src.StatName.ValueString(),
+		Timeout:                                   c.Duration(path.Root("timeout"), src.Timeout),
+		TlsClientKeyPairId:                        src.TLSClientKeyPairID.ValueStringPointer(),
+		TlsCustomCaKeyPairId:                      src.TLSCustomCAKeyPairID.ValueStringPointer(),
+		TlsDownstreamClientCaKeyPairId:            nil, // not supported
+		TlsDownstreamServerName:                   src.TLSDownstreamServerName.ValueStringPointer(),
+		TlsSkipVerify:                             src.TLSSkipVerify.ValueBoolPointer(),
+		TlsUpstreamAllowRenegotiation:             src.TLSUpstreamAllowRenegotiation.ValueBoolPointer(),
+		TlsUpstreamServerName:                     src.TLSUpstreamServerName.ValueStringPointer(),
+		To:                                        c.StringSliceFromSet(path.Root("to"), src.To),
+		UpstreamTunnel:                            c.UpstreamTunnel(path.Root("upstream_tunnel"), src.UpstreamTunnel),
 	}
 }
 
@@ -445,8 +485,9 @@ func (c *ModelToEnterpriseConverter) RouteRewriteHeader(src types.Object) *enter
 
 	prefixAttr := src.Attributes()["prefix"].(types.String)
 	dst := &enterprise.RouteRewriteHeader{
-		Header: src.Attributes()["header"].(types.String).ValueString(),
-		Value:  src.Attributes()["value"].(types.String).ValueString(),
+		Header:  src.Attributes()["header"].(types.String).ValueString(),
+		Matcher: nil, // set below
+		Value:   src.Attributes()["value"].(types.String).ValueString(),
 	}
 	if !prefixAttr.IsNull() && prefixAttr.ValueString() != "" {
 		dst.Matcher = &enterprise.RouteRewriteHeader_Prefix{Prefix: prefixAttr.ValueString()}
@@ -483,15 +524,18 @@ func (c *ModelToEnterpriseConverter) Settings(src SettingsModel) *enterprise.Set
 		AuthenticateServiceUrl:        src.AuthenticateServiceURL.ValueStringPointer(),
 		AuthorizeLogFields:            c.SettingsStringList(path.Root("authorize_log_fields"), src.AuthorizeLogFields),
 		AuthorizeServiceUrl:           src.AuthorizeServiceURL.ValueStringPointer(),
+		AutoApplyChangesets:           src.AutoApplyChangesets.ValueBoolPointer(),
 		Autocert:                      src.Autocert.ValueBoolPointer(),
 		AutocertDir:                   src.AutocertDir.ValueStringPointer(),
 		AutocertMustStaple:            src.AutocertMustStaple.ValueBoolPointer(),
 		AutocertUseStaging:            src.AutocertUseStaging.ValueBoolPointer(),
 		BearerTokenFormat:             c.BearerTokenFormat(path.Root("bearer_token_format"), src.BearerTokenFormat),
+		BlobStorage:                   c.BlobStorage(src.BlobStorage),
 		CacheServiceUrl:               src.CacheServiceURL.ValueStringPointer(),
 		CertificateAuthority:          src.CertificateAuthority.ValueStringPointer(),
 		CertificateAuthorityFile:      src.CertificateAuthorityFile.ValueStringPointer(),
 		CertificateAuthorityKeyPairId: src.CertificateAuthorityKeyPairID.ValueStringPointer(),
+		Certificates:                  nil, // sent as key pairs
 		CircuitBreakerThresholds:      c.CircuitBreakerThresholds(src.CircuitBreakerThresholds),
 		ClientCa:                      src.ClientCA.ValueStringPointer(),
 		ClientCaFile:                  src.ClientCAFile.ValueStringPointer(),
@@ -545,6 +589,7 @@ func (c *ModelToEnterpriseConverter) Settings(src SettingsModel) *enterprise.Set
 		McpAllowedAsMetadataDomains:     c.SettingsStringList(path.Root("mcp_allowed_as_metadata_domains"), src.MCPAllowedAsMetadataDomains),
 		McpAllowedClientIdDomains:       c.SettingsStringList(path.Root("mcp_allowed_client_id_domains"), src.MCPAllowedClientIDDomains),
 		MetricsAddress:                  src.MetricsAddress.ValueStringPointer(),
+		ModifiedAt:                      nil, // computed
 		OriginatorId:                    OriginatorID,
 		OtelAttributeValueLengthLimit:   c.NullableInt32(src.OtelAttributeValueLengthLimit),
 		OtelBspMaxExportBatchSize:       c.NullableInt32(src.OtelBspMaxExportBatchSize),
@@ -567,7 +612,10 @@ func (c *ModelToEnterpriseConverter) Settings(src SettingsModel) *enterprise.Set
 		RequestParams:                   c.StringMap(path.Root("request_params"), src.RequestParams),
 		Scopes:                          c.StringSliceFromSet(path.Root("scopes"), src.Scopes),
 		SecondaryColor:                  src.SecondaryColor.ValueStringPointer(),
+		Services:                        nil, // not supported
+		SessionRecordingEnabled:         nil, // not supported
 		SetResponseHeaders:              c.StringMap(path.Root("set_response_headers"), src.SetResponseHeaders),
+		SharedSecret:                    nil, // not supported
 		SkipXffAppend:                   src.SkipXFFAppend.ValueBoolPointer(),
 		SshAddress:                      src.SSHAddress.ValueStringPointer(),
 		SshHostKeyFiles:                 c.SettingsStringList(path.Root("ssh_host_key_files"), src.SSHHostKeyFiles),
@@ -598,4 +646,26 @@ func (c *ModelToEnterpriseConverter) UpdateKeyPairRequest(src KeyPairModel) *ent
 		Name:         c.NullableString(src.Name),
 		OriginatorId: OriginatorID,
 	}
+}
+
+func (c *ModelToEnterpriseConverter) UpstreamTunnel(p path.Path, src types.Object) *enterprise.UpstreamTunnel {
+	if src.IsNull() || src.IsUnknown() {
+		return nil
+	}
+
+	dst := new(enterprise.UpstreamTunnel)
+	for k, v := range src.Attributes() {
+		switch k {
+		case "ssh_policy":
+			str, ok := v.(types.String)
+			if ok {
+				dst.SshPolicyId = str.ValueStringPointer()
+			} else {
+				c.diagnostics.AddAttributeError(p.AtName("ssh_policy"), "unexpected type for field", fmt.Sprintf("unexpected type for field: %T", v))
+			}
+		default:
+			c.diagnostics.AddAttributeError(p, "unknown object field", fmt.Sprintf("unknown object field: %s", k))
+		}
+	}
+	return dst
 }

--- a/internal/provider/external_data_source_data_source.go
+++ b/internal/provider/external_data_source_data_source.go
@@ -16,13 +16,13 @@ import (
 	"github.com/pomerium/sdk-go"
 )
 
-var (
-	_ datasource.DataSource              = &ExternalDataSourceDataSource{}
-	_ datasource.DataSourceWithConfigure = &ExternalDataSourceDataSource{}
-)
+var _ interface {
+	datasource.DataSource
+	datasource.DataSourceWithConfigure
+} = (*ExternalDataSourceDataSource)(nil)
 
 func NewExternalDataSourceDataSource() datasource.DataSource {
-	return &ExternalDataSourceDataSource{}
+	return new(ExternalDataSourceDataSource)
 }
 
 // ExternalDataSourceDataSource defines the data source implementation.

--- a/internal/provider/external_data_source_resource.go
+++ b/internal/provider/external_data_source_resource.go
@@ -20,13 +20,13 @@ import (
 	"github.com/pomerium/sdk-go"
 )
 
-var (
-	_ resource.Resource                = &ExternalDataSourceResource{}
-	_ resource.ResourceWithImportState = &ExternalDataSourceResource{}
-)
+var _ interface {
+	resource.Resource
+	resource.ResourceWithImportState
+} = (*ExternalDataSourceResource)(nil)
 
 func NewExternalDataSourceResource() resource.Resource {
-	return &ExternalDataSourceResource{}
+	return new(ExternalDataSourceResource)
 }
 
 // ExternalDataSourceResource defines the resource implementation.

--- a/internal/provider/key_pair_resource.go
+++ b/internal/provider/key_pair_resource.go
@@ -20,10 +20,10 @@ import (
 	"github.com/pomerium/sdk-go/proto/pomerium"
 )
 
-var (
-	_ resource.Resource                = &KeyPairResource{}
-	_ resource.ResourceWithImportState = &KeyPairResource{}
-)
+var _ interface {
+	resource.Resource
+	resource.ResourceWithImportState
+} = (*KeyPairResource)(nil)
 
 type KeyPairResource struct {
 	client *Client
@@ -33,7 +33,7 @@ type KeyPairResource struct {
 type KeyPairResourceModel = KeyPairModel
 
 func NewKeyPairResource() resource.Resource {
-	return &KeyPairResource{}
+	return new(KeyPairResource)
 }
 
 func (r *KeyPairResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {

--- a/internal/provider/namespace_data_source.go
+++ b/internal/provider/namespace_data_source.go
@@ -11,10 +11,12 @@ import (
 	"github.com/pomerium/sdk-go"
 )
 
-var _ datasource.DataSource = &NamespaceDataSource{}
+var _ interface {
+	datasource.DataSource
+} = (*NamespaceDataSource)(nil)
 
 func NewNamespaceDataSource() datasource.DataSource {
-	return &NamespaceDataSource{}
+	return new(NamespaceDataSource)
 }
 
 type NamespaceDataSource struct {

--- a/internal/provider/namespace_permission_resource.go
+++ b/internal/provider/namespace_permission_resource.go
@@ -25,7 +25,7 @@ import (
 var namespacePermissionMD string
 
 func NewNamespacePermissionResource() resource.Resource {
-	return &NamespacePermissionResource{}
+	return new(NamespacePermissionResource)
 }
 
 type NamespacePermissionResource struct {

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -19,14 +19,14 @@ import (
 )
 
 // Ensure provider-defined types fully satisfy framework interfaces.
-var (
-	_ resource.Resource                = &NamespaceResource{}
-	_ resource.ResourceWithImportState = &NamespaceResource{}
-)
+var _ interface {
+	resource.Resource
+	resource.ResourceWithImportState
+} = (*NamespaceResource)(nil)
 
 // NewNamespaceResource creates a new NamespaceResource.
 func NewNamespaceResource() resource.Resource {
-	return &NamespaceResource{}
+	return new(NamespaceResource)
 }
 
 // NamespaceResource defines the resource implementation.

--- a/internal/provider/namespaces_data_source.go
+++ b/internal/provider/namespaces_data_source.go
@@ -14,10 +14,12 @@ import (
 
 var GlobalNamespaceID = "9d8dbd2c-8cce-4e66-9c1f-c490b4a07243"
 
-var _ datasource.DataSource = &NamespacesDataSource{}
+var _ interface {
+	datasource.DataSource
+} = (*NamespacesDataSource)(nil)
 
 func NewNamespacesDataSource() datasource.DataSource {
-	return &NamespacesDataSource{}
+	return new(NamespacesDataSource)
 }
 
 type NamespacesDataSource struct {

--- a/internal/provider/policies_data_source.go
+++ b/internal/provider/policies_data_source.go
@@ -15,10 +15,12 @@ import (
 	"github.com/pomerium/sdk-go"
 )
 
-var _ datasource.DataSource = &PoliciesDataSource{}
+var _ interface {
+	datasource.DataSource
+} = (*PoliciesDataSource)(nil)
 
 func NewPoliciesDataSource() datasource.DataSource {
-	return &PoliciesDataSource{}
+	return new(PoliciesDataSource)
 }
 
 type PoliciesDataSource struct {

--- a/internal/provider/policy_data_source.go
+++ b/internal/provider/policy_data_source.go
@@ -14,10 +14,12 @@ import (
 	"github.com/pomerium/sdk-go/proto/pomerium"
 )
 
-var _ datasource.DataSource = &PolicyDataSource{}
+var _ interface {
+	datasource.DataSource
+} = (*PolicyDataSource)(nil)
 
 func NewPolicyDataSource() datasource.DataSource {
-	return &PolicyDataSource{}
+	return new(PolicyDataSource)
 }
 
 type PolicyDataSource struct {

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -24,15 +24,15 @@ import (
 )
 
 // Ensure provider-defined types fully satisfy framework interfaces.
-var (
-	_ resource.Resource                = (*PolicyResource)(nil)
-	_ resource.ResourceWithConfigure   = (*PolicyResource)(nil)
-	_ resource.ResourceWithImportState = (*PolicyResource)(nil)
-)
+var _ interface {
+	resource.Resource
+	resource.ResourceWithConfigure
+	resource.ResourceWithImportState
+} = (*PolicyResource)(nil)
 
 // NewPolicyResource creates a new PolicyResource.
 func NewPolicyResource() resource.Resource {
-	return &PolicyResource{}
+	return new(PolicyResource)
 }
 
 // PolicyResource defines the resource implementation.
@@ -137,8 +137,10 @@ func (r *PolicyResource) Create(ctx context.Context, req resource.CreateRequest,
 				},
 				func(filter *structpb.Struct) ([]*pomerium.Policy, error) {
 					listReq := newConnectRequest(&pomerium.ListPoliciesRequest{
-						Limit:  new(uint64(1)),
-						Filter: filter,
+						Filter:  filter,
+						Limit:   new(uint64(1)),
+						Offset:  new(uint64(0)),
+						OrderBy: nil,
 					}, apiPolicy)
 					listRes, err := client.ListPolicies(ctx, listReq)
 					if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -17,8 +17,10 @@ import (
 )
 
 var (
-	_ provider.Provider              = &PomeriumProvider{}
-	_ provider.ProviderWithFunctions = &PomeriumProvider{}
+	_ interface {
+		provider.Provider
+		provider.ProviderWithFunctions
+	} = (*PomeriumProvider)(nil)
 
 	//go:embed help/provider.md
 	providerDescription string
@@ -91,7 +93,7 @@ func (p *PomeriumProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
-	tlsConfig := &tls.Config{InsecureSkipVerify: data.TLSInsecureSkipVerify.ValueBool()} //nolint: gosec
+	tlsConfig := &tls.Config{InsecureSkipVerify: data.TLSInsecureSkipVerify.ValueBool()} //nolint
 
 	var serviceAccountToken string
 	if !data.ServiceAccountToken.IsNull() {

--- a/internal/provider/route_data_source.go
+++ b/internal/provider/route_data_source.go
@@ -17,7 +17,9 @@ import (
 	"github.com/pomerium/sdk-go/proto/pomerium"
 )
 
-var _ datasource.DataSource = &RouteDataSource{}
+var _ interface {
+	datasource.DataSource
+} = (*RouteDataSource)(nil)
 
 func getRouteDataSourceAttributes(idRequired bool) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
@@ -404,7 +406,7 @@ func getRouteDataSourceAttributes(idRequired bool) map[string]schema.Attribute {
 }
 
 func NewRouteDataSource() datasource.DataSource {
-	return &RouteDataSource{}
+	return new(RouteDataSource)
 }
 
 type RouteDataSource struct {

--- a/internal/provider/route_resource.go
+++ b/internal/provider/route_resource.go
@@ -27,13 +27,13 @@ import (
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
-var (
-	_ resource.Resource                = &RouteResource{}
-	_ resource.ResourceWithImportState = &RouteResource{}
-)
+var _ interface {
+	resource.Resource
+	resource.ResourceWithImportState
+} = (*RouteResource)(nil)
 
 func NewRouteResource() resource.Resource {
-	return &RouteResource{}
+	return new(RouteResource)
 }
 
 // RouteResource defines the resource implementation.

--- a/internal/provider/routes_data_source.go
+++ b/internal/provider/routes_data_source.go
@@ -15,10 +15,12 @@ import (
 	"github.com/pomerium/sdk-go"
 )
 
-var _ datasource.DataSource = &RoutesDataSource{}
+var _ interface {
+	datasource.DataSource
+} = (*RoutesDataSource)(nil)
 
 func NewRoutesDataSource() datasource.DataSource {
-	return &RoutesDataSource{}
+	return new(RoutesDataSource)
 }
 
 type RoutesDataSource struct {

--- a/internal/provider/service_account_data_source.go
+++ b/internal/provider/service_account_data_source.go
@@ -13,10 +13,12 @@ import (
 	"github.com/pomerium/sdk-go/proto/pomerium"
 )
 
-var _ datasource.DataSource = &ServiceAccountDataSource{}
+var _ interface {
+	datasource.DataSource
+} = (*ServiceAccountDataSource)(nil)
 
 func NewServiceAccountDataSource() datasource.DataSource {
-	return &ServiceAccountDataSource{}
+	return new(ServiceAccountDataSource)
 }
 
 type ServiceAccountDataSource struct {
@@ -86,7 +88,8 @@ func (d *ServiceAccountDataSource) Read(ctx context.Context, req datasource.Read
 		},
 		func(client *client.Client) {
 			getReq := &pb.GetPomeriumServiceAccountRequest{
-				Id: data.ID.ValueString(),
+				ClusterId: nil,
+				Id:        data.ID.ValueString(),
 			}
 			getRes, err := client.PomeriumServiceAccountService.GetPomeriumServiceAccount(ctx, getReq)
 			if err != nil {

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -20,13 +20,13 @@ import (
 	"github.com/pomerium/sdk-go/proto/pomerium"
 )
 
-var (
-	_ resource.Resource                = &ServiceAccountResource{}
-	_ resource.ResourceWithImportState = &ServiceAccountResource{}
-)
+var _ interface {
+	resource.Resource
+	resource.ResourceWithImportState
+} = (*ServiceAccountResource)(nil)
 
 func NewServiceAccountResource() resource.Resource {
-	return &ServiceAccountResource{}
+	return new(ServiceAccountResource)
 }
 
 type ServiceAccountResource struct {
@@ -131,6 +131,7 @@ func (r *ServiceAccountResource) Create(ctx context.Context, req resource.Create
 			}
 
 			addReq := &pb.AddPomeriumServiceAccountRequest{
+				ClusterId:      nil,
 				ServiceAccount: pbServiceAccount,
 			}
 			addRes, err := client.PomeriumServiceAccountService.AddPomeriumServiceAccount(ctx, addReq)
@@ -184,7 +185,8 @@ func (r *ServiceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 		},
 		func(client *client.Client) {
 			getReq := &pb.GetPomeriumServiceAccountRequest{
-				Id: state.ID.ValueString(),
+				ClusterId: nil,
+				Id:        state.ID.ValueString(),
 			}
 			getRes, err := client.PomeriumServiceAccountService.GetPomeriumServiceAccount(ctx, getReq)
 			if err != nil {
@@ -238,6 +240,7 @@ func (r *ServiceAccountResource) Update(ctx context.Context, req resource.Update
 			}
 
 			setReq := &pb.SetPomeriumServiceAccountRequest{
+				ClusterId:      nil,
 				ServiceAccount: pbServiceAccount,
 			}
 			_, err := client.PomeriumServiceAccountService.SetPomeriumServiceAccount(ctx, setReq)
@@ -274,7 +277,8 @@ func (r *ServiceAccountResource) Delete(ctx context.Context, req resource.Delete
 		},
 		func(client *client.Client) {
 			deleteReq := &pb.DeletePomeriumServiceAccountRequest{
-				Id: state.ID.ValueString(),
+				ClusterId: nil,
+				Id:        state.ID.ValueString(),
 			}
 			_, err := client.PomeriumServiceAccountService.DeletePomeriumServiceAccount(ctx, deleteReq)
 			if err != nil {

--- a/internal/provider/service_account_resource_test.go
+++ b/internal/provider/service_account_resource_test.go
@@ -20,7 +20,8 @@ func TestAccServiceAccount(t *testing.T) {
 				Config: testAccServiceAccountConfig(t, apiURL, sharedSecret, "test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("pomerium_service_account.test", "id"),
-					resource.TestCheckResourceAttrSet("pomerium_service_account.test", "name"),
+					resource.TestCheckResourceAttr("pomerium_service_account.test", "name", "test"),
+					resource.TestCheckResourceAttr("pomerium_service_account.test", "user_id", "test"),
 				),
 			},
 		},

--- a/internal/provider/service_accounts_data_source.go
+++ b/internal/provider/service_accounts_data_source.go
@@ -13,10 +13,12 @@ import (
 	"github.com/pomerium/sdk-go"
 )
 
-var _ datasource.DataSource = &ServiceAccountsDataSource{}
+var _ interface {
+	datasource.DataSource
+} = (*ServiceAccountsDataSource)(nil)
 
 func NewServiceAccountsDataSource() datasource.DataSource {
-	return &ServiceAccountsDataSource{}
+	return new(ServiceAccountsDataSource)
 }
 
 type ServiceAccountsDataSource struct {
@@ -113,6 +115,7 @@ func (d *ServiceAccountsDataSource) Read(ctx context.Context, req datasource.Rea
 		},
 		func(client *client.Client) {
 			listReq := &pb.ListPomeriumServiceAccountsRequest{
+				ClusterId: nil,
 				Namespace: data.NamespaceID.ValueString(),
 			}
 			listRes, err := client.PomeriumServiceAccountService.ListPomeriumServiceAccounts(ctx, listReq)

--- a/internal/provider/settings_resource.go
+++ b/internal/provider/settings_resource.go
@@ -13,13 +13,13 @@ import (
 	"github.com/pomerium/sdk-go/proto/pomerium"
 )
 
-var (
-	_ resource.Resource                = &SettingsResource{}
-	_ resource.ResourceWithImportState = &SettingsResource{}
-)
+var _ interface {
+	resource.Resource
+	resource.ResourceWithImportState
+} = (*SettingsResource)(nil)
 
 func NewSettingsResource() resource.Resource {
-	return &SettingsResource{}
+	return new(SettingsResource)
 }
 
 type SettingsResource struct {

--- a/main.go
+++ b/main.go
@@ -7,9 +7,10 @@ import (
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/pomerium/enterprise-terraform-provider/internal/provider"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/grpclog"
+
+	"github.com/pomerium/enterprise-terraform-provider/internal/provider"
 )
 
 var version = "dev"
@@ -31,8 +32,9 @@ func main() {
 		// TODO: Update this string with the published name of your provider.
 		// Also update the tfplugindocs generate command to either remove the
 		// -provider-name flag or set its value to the updated provider name.
-		Address: "registry.terraform.io/pomerium/pomerium",
-		Debug:   debug,
+		Address:         "registry.terraform.io/pomerium/pomerium",
+		Debug:           debug,
+		ProtocolVersion: 6,
 	}
 
 	err := providerserver.Serve(context.Background(), provider.New(version), opts)


### PR DESCRIPTION
Add some missing legacy fields: `BlobStorage`, `UpstreamTunnel` and add an `exhaustruct` linter to catch this going forward.

For [ENG-3734](https://linear.app/pomerium/issue/ENG-3734/terraform-pomerium-routes-data-source-fails-with-value-conversion)