### PR TITLE
terraform/settings: preserve blob_storage.managed_prefix on enterprise read

### DIFF
--- a/internal/provider/converters_enterprise_to_model.go
+++ b/internal/provider/converters_enterprise_to_model.go
@@ -30,7 +30,7 @@ func (c *EnterpriseToModelConverter) BlobStorageSettings(src *enterprise.BlobSto
 	}
 	dst, diagnostics := types.ObjectValue(BlobStorageSettingsObjectType().AttrTypes, map[string]attr.Value{
 		"bucket_uri":     types.StringPointerValue(src.BucketUri),
-		"managed_prefix": types.StringNull(),
+		"managed_prefix": types.StringPointerValue(src.ManagedPrefix),
 	})
 	c.diagnostics.Append(diagnostics...)
 	return dst

--- a/internal/provider/converters_enterprise_to_model_test.go
+++ b/internal/provider/converters_enterprise_to_model_test.go
@@ -20,6 +20,28 @@ import (
 func TestEnterpriseToModelConverter(t *testing.T) {
 	t.Parallel()
 
+	t.Run("BlobStorageSettings", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range []struct {
+			src    *pb.BlobStorageSettings
+			expect types.Object
+		}{
+			{nil, types.ObjectNull(provider.BlobStorageSettingsObjectType().AttrTypes)},
+			{&pb.BlobStorageSettings{
+				BucketUri:     new("s3://example-bucket"),
+				ManagedPrefix: new("tenants/acme/"),
+			}, types.ObjectValueMust(provider.BlobStorageSettingsObjectType().AttrTypes, map[string]attr.Value{
+				"bucket_uri":     types.StringValue("s3://example-bucket"),
+				"managed_prefix": types.StringValue("tenants/acme/"),
+			})},
+		} {
+			var diagnostics diag.Diagnostics
+			actual := provider.NewEnterpriseToModelConverter(&diagnostics).BlobStorageSettings(tc.src)
+			assert.Empty(t, diagnostics)
+			assert.Equal(t, tc.expect, actual)
+		}
+	})
 	t.Run("CircuitBreakerThresholds", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
The enterprise read path for `blob_storage` was dropping the `managed_prefix` field, leaving it null in state even when the API returned a value. Enterprise users who set `managed_prefix` saw a perpetual diff on plan.

The write path and the non-enterprise read path already handle the field correctly — this brings the enterprise read path in line. A regression test covers the converter.

Fixes ENG-3942.