### PR TITLE
fix: remove blob storage settings managed prefix from terraform provider API

### DIFF
--- a/docs/resources/settings.md
+++ b/docs/resources/settings.md
@@ -139,7 +139,6 @@ The settings are global object.
 Optional:
 
 - `bucket_uri` (String, Sensitive)
-- `managed_prefix` (String)
 
 
 <a id="nestedatt--circuit_breaker_thresholds"></a>

--- a/internal/provider/converters_api_to_model.go
+++ b/internal/provider/converters_api_to_model.go
@@ -32,8 +32,7 @@ func (c *APIToModelConverter) BlobStorageSettings(src *pomerium.BlobStorageSetti
 		return types.ObjectNull(BlobStorageSettingsObjectType().AttrTypes)
 	}
 	dst, diagnostics := types.ObjectValue(BlobStorageSettingsObjectType().AttrTypes, map[string]attr.Value{
-		"bucket_uri":     types.StringPointerValue(src.BucketUri),
-		"managed_prefix": types.StringPointerValue(src.ManagedPrefix),
+		"bucket_uri": types.StringPointerValue(src.BucketUri),
 	})
 	c.diagnostics.Append(diagnostics...)
 	return dst

--- a/internal/provider/converters_api_to_model_test.go
+++ b/internal/provider/converters_api_to_model_test.go
@@ -458,8 +458,7 @@ func TestAPIToModel(t *testing.T) {
 				AuthorizeServiceUrls:   []string{"https://authorize.example.com"},
 				Autocert:               new(true),
 				BlobStorage: &pomerium.BlobStorageSettings{
-					BucketUri:     new("BUCKET_URI"),
-					ManagedPrefix: new("MANAGED_PREFIX"),
+					BucketUri: new("BUCKET_URI"),
 				},
 				CertificateAuthority:              new("CA_CERT"),
 				ClusterId:                         new("CLUSTER_ID"),
@@ -510,8 +509,7 @@ func TestAPIToModel(t *testing.T) {
 			assert.Equal(t, types.StringValue("https://authorize.example.com"), result.AuthorizeServiceURL)
 			assert.Equal(t, types.BoolValue(true), result.Autocert)
 			assert.Equal(t, types.ObjectValueMust(provider.BlobStorageSettingsObjectType().AttrTypes, map[string]attr.Value{
-				"bucket_uri":     types.StringValue("BUCKET_URI"),
-				"managed_prefix": types.StringValue("MANAGED_PREFIX"),
+				"bucket_uri": types.StringValue("BUCKET_URI"),
 			}), result.BlobStorage)
 			assert.Equal(t, types.StringValue("CA_CERT"), result.CertificateAuthority)
 			assert.Equal(t, types.StringValue("CLUSTER_ID"), result.ClusterID)

--- a/internal/provider/converters_enterprise_to_model.go
+++ b/internal/provider/converters_enterprise_to_model.go
@@ -29,8 +29,7 @@ func (c *EnterpriseToModelConverter) BlobStorageSettings(src *enterprise.BlobSto
 		return types.ObjectNull(BlobStorageSettingsObjectType().AttrTypes)
 	}
 	dst, diagnostics := types.ObjectValue(BlobStorageSettingsObjectType().AttrTypes, map[string]attr.Value{
-		"bucket_uri":     types.StringPointerValue(src.BucketUri),
-		"managed_prefix": types.StringNull(),
+		"bucket_uri": types.StringPointerValue(src.BucketUri),
 	})
 	c.diagnostics.Append(diagnostics...)
 	return dst

--- a/internal/provider/converters_model_to_api.go
+++ b/internal/provider/converters_model_to_api.go
@@ -36,10 +36,9 @@ func (c *ModelToAPIConverter) BlobStorageSettings(src types.Object) *pomerium.Bl
 
 	attrs := src.Attributes()
 	bucketURI, _ := attrs["bucket_uri"].(types.String)
-	managedPrefix, _ := attrs["managed_prefix"].(types.String)
 	return &pomerium.BlobStorageSettings{
 		BucketUri:     c.NullableString(bucketURI),
-		ManagedPrefix: c.NullableString(managedPrefix),
+		ManagedPrefix: nil,
 	}
 }
 

--- a/internal/provider/converters_model_to_api_test.go
+++ b/internal/provider/converters_model_to_api_test.go
@@ -279,8 +279,7 @@ func TestModelToAPI(t *testing.T) {
 				AuthorizeServiceURL:    types.StringValue("https://authorize.example.com"),
 				Autocert:               types.BoolValue(true),
 				BlobStorage: types.ObjectValueMust(provider.BlobStorageSettingsObjectType().AttrTypes, map[string]attr.Value{
-					"bucket_uri":     types.StringValue("BUCKET_URI"),
-					"managed_prefix": types.StringValue("MANAGED_PREFIX"),
+					"bucket_uri": types.StringValue("BUCKET_URI"),
 				}),
 				CertificateAuthority:              types.StringValue("CA_CERT"),
 				ClusterID:                         types.StringValue("CLUSTER_ID"),
@@ -328,7 +327,7 @@ func TestModelToAPI(t *testing.T) {
 			assert.Equal(t, new("https://authenticate.example.com"), result.AuthenticateServiceUrl)
 			assert.Equal(t, []string{"https://authorize.example.com"}, result.AuthorizeServiceUrls)
 			assert.Equal(t, new(true), result.Autocert)
-			assert.Empty(t, cmp.Diff(&pomerium.BlobStorageSettings{BucketUri: new("BUCKET_URI"), ManagedPrefix: new("MANAGED_PREFIX")}, result.BlobStorage, protocmp.Transform()))
+			assert.Empty(t, cmp.Diff(&pomerium.BlobStorageSettings{BucketUri: new("BUCKET_URI")}, result.BlobStorage, protocmp.Transform()))
 			assert.Equal(t, new("CA_CERT"), result.CertificateAuthority)
 			assert.Equal(t, new("CLUSTER_ID"), result.ClusterId)
 			assert.Equal(t, new(".example.com"), result.CookieDomain)

--- a/internal/provider/converters_model_to_enterprise.go
+++ b/internal/provider/converters_model_to_enterprise.go
@@ -33,10 +33,9 @@ func (c *ModelToEnterpriseConverter) BlobStorage(src types.Object) *enterprise.B
 
 	attrs := src.Attributes()
 	bucketURI, _ := attrs["bucket_uri"].(types.String)
-	managedPrefix, _ := attrs["managed_prefix"].(types.String)
 	return &enterprise.BlobStorageSettings{
 		BucketUri:     c.NullableString(bucketURI),
-		ManagedPrefix: c.NullableString(managedPrefix),
+		ManagedPrefix: nil,
 	}
 }
 

--- a/internal/provider/models_objects.go
+++ b/internal/provider/models_objects.go
@@ -9,8 +9,7 @@ import (
 func BlobStorageSettingsObjectType() types.ObjectType {
 	return types.ObjectType{
 		AttrTypes: map[string]attr.Type{
-			"bucket_uri":     types.StringType,
-			"managed_prefix": types.StringType,
+			"bucket_uri": types.StringType,
 		},
 	}
 }

--- a/internal/provider/settings_schema.go
+++ b/internal/provider/settings_schema.go
@@ -119,9 +119,6 @@ var SettingsResourceSchema = schema.Schema{
 					Optional:  true,
 					Sensitive: true,
 				},
-				"managed_prefix": schema.StringAttribute{
-					Optional: true,
-				},
 			},
 		},
 		"cache_service_url": schema.StringAttribute{


### PR DESCRIPTION
https://github.com/pomerium/terraform-provider-pomerium/pull/226#discussion_r3127376377

managed_prefix is managed internally by the cluster syncer, so should be omitted from the terraform provider API surface area