### PR TITLE
ci: update Go toolchain to 1.26.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golangci-lint 2.12.2
-golang 1.26.4
+golang 1.26.5


### PR DESCRIPTION
## What

This updates the Terraform Provider CI toolchain pin to Go 1.26.5.

## Why

GO-2026-5856 is fixed in Go 1.26.5. Provider releases should be built with the patched compiler.

## Testing

The compile-only Go test suite passed with Go 1.26.5.

## Related issue

- [ENG-4243](https://linear.app/pomerium/issue/ENG-4243)

## AI assistance

Codex made the toolchain-only edit and ran validation. Bobby directed the scope.