### PR TITLE
[0.33.0] backport:fix cast math.MaxUint32 to int64 (#266)

### DIFF
--- a/internal/provider/converters.go
+++ b/internal/provider/converters.go
@@ -359,7 +359,7 @@ func (c *baseModelConverter) NullableUint32(src types.Int64) *uint32 {
 	}
 	v := src.ValueInt64()
 	if v < 0 || v > math.MaxUint32 {
-		c.diagnostics.AddError("value out of range for uint32", fmt.Sprintf("value %d is outside uint32 range [0, %d]", v, math.MaxUint32))
+		c.diagnostics.AddError("value out of range for uint32", fmt.Sprintf("value %d is outside uint32 range [0, %d]", v, int64(math.MaxUint32)))
 		return nil
 	}
 	return new(uint32(v))


### PR DESCRIPTION
Looks like the terraform provider release CI is failing because:
```go
func (c *baseModelConverter) NullableUint32(src types.Int64) *uint32 {
	if src.IsNull() || src.IsUnknown() {
		return nil
	}
	v := src.ValueInt64()
	if v < 0 || v > math.MaxUint32 {
		c.diagnostics.AddError("value out of range for uint32", fmt.Sprintf("value %d is outside uint32 range [0, %d]", v, math.MaxUint32))
		return nil
	}
	return new(uint32(v))
}
```
overflows on the GOOS=freebsd GOARCH=arm go build.