### PR TITLE
ci: stop dependabot from bumping pomerium modules

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,5 +16,9 @@ updates:
       go:
         patterns:
           - "*"
-        exclude-patterns:
-          - "github.com/pomerium/*"
+    # github.com/pomerium/* modules are managed by scripts/update-dependencies,
+    # which tracks @main on main and is not run on the release branches.
+    # Merely excluding them from the group is not enough: dependabot still opens
+    # an individual PR per module, moving main off of @main and onto a tag.
+    ignore:
+      - dependency-name: "github.com/pomerium/*"


### PR DESCRIPTION
`main` is supposed to follow every `github.com/pomerium/*` module from `pomerium/pomerium@main` — `scripts/update-dependencies pomerium` already does that for the root module, `pkg/grpc/config`, `pkg/grpc/databroker`, `protoutil`, `sdk-go` and `enterprise-client-go`, and `update-branch-dependencies.yaml` runs it nightly for `main` only (release branches deliberately stay on their tag).

Dependabot was fighting that. `exclude-patterns` on the `go` group only keeps those modules *out of the grouped PR*; dependabot still opens an individual PR per module. That's #275 and #276, which move `main` from a `@main` pseudo-version back onto the `v0.33.0` tag — a regression the nightly job then reverts.

Ignore `github.com/pomerium/*` in the `gomod` ecosystem instead, so `scripts/update-dependencies` is the only thing touching those versions.

Note: `ignore` also suppresses dependabot *security* PRs for these modules. Acceptable here, since `main` picks up upstream fixes within a day via the nightly `@main` bump.

Supersedes #275 and #276 (closed manually).