### PR TITLE
chore: upgrade to go 1.27

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
     - dogsled
     - errcheck
     - errorlint
-    - exhaustruct
+    - exhaustruct_v5
     - gocheckcompilerdirectives
     - goprintffuncname
     - gosec
@@ -34,7 +34,7 @@ linters:
       - linters:
           - bodyclose
           - errcheck
-          - exhaustruct
+          - exhaustruct_v5
           - gosec
           - staticcheck
           - unused
@@ -55,7 +55,7 @@ linters:
           - revive
         text: should have a package comment
       - linters:
-          - exhaustruct
+          - exhaustruct_v5
         text: ^((schema|timetypes)[.][a-zA-Z0-9]+|provider.PolicyLanguage|provider.PolicyLanguageType)[ ]is missing
     paths:
       - third_party$

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golangci-lint 2.13.1
-golang 1.26.7
+golang 1.27.0

--- a/internal/provider/databroker.go
+++ b/internal/provider/databroker.go
@@ -25,10 +25,12 @@ func databrokerDelete(
 	}
 	_, err = client.Put(ctx, &databrokerpb.PutRequest{
 		Records: []*databrokerpb.Record{{
-			Type:      recordType,
-			Id:        recordID,
-			Data:      anyData,
-			DeletedAt: timestamppb.Now(),
+			Version:    0,
+			Type:       recordType,
+			Id:         recordID,
+			Data:       anyData,
+			ModifiedAt: nil,
+			DeletedAt:  timestamppb.Now(),
 		}},
 	})
 	return err
@@ -105,9 +107,12 @@ func databrokerPut(
 	}
 	_, err = client.Put(ctx, &databrokerpb.PutRequest{
 		Records: []*databrokerpb.Record{{
-			Type: recordType,
-			Id:   recordID,
-			Data: anyData,
+			Version:    0,
+			Type:       recordType,
+			Id:         recordID,
+			ModifiedAt: nil,
+			DeletedAt:  nil,
+			Data:       anyData,
 		}},
 	})
 	return err

--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -31,8 +31,8 @@ update-tools() {
 
 	require-command asdf
 
-	asdf install golang latest:1.26
-	asdf set golang latest:1.26
+	asdf install golang latest:1.27
+	asdf set golang latest:1.27
 	asdf install golangci-lint latest:2
 	asdf set golangci-lint latest:2
 


### PR DESCRIPTION
Upgrade to go 1.27.

- [ENG-4338](https://linear.app/pomerium/issue/ENG-4338/various-upgrade-go-to-127)